### PR TITLE
Casting pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,6 @@ in your C++ code. Then, use the following flag for linking:
 ```
 -lbft_(static|shared)
 ```
-and the following flag for compiling:
-```
--fpermissive
-```
 
 ### Non-default installations
 

--- a/include/CC.h
+++ b/include/CC.h
@@ -119,10 +119,10 @@ uint16_t** build_skip_nodes(Node* node);
 void free_skip_nodes(Node* node, uint16_t** skp_nodes);
 
 inline CC* createCC(int nb_bits_bf){
-    CC* cc = malloc(sizeof(CC));
+    CC* cc = (CC*) malloc(sizeof(CC));
     ASSERT_NULL_PTR(cc,"createCC()")
 
-    cc->BF_filter2 = calloc((nb_bits_bf/SIZE_BITS_UINT_8T)+(SIZE_FILTER2_DEFAULT/SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    cc->BF_filter2 = (uint8_t*) calloc((nb_bits_bf/SIZE_BITS_UINT_8T)+(SIZE_FILTER2_DEFAULT/SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->BF_filter2,"createCC()")
 
     cc->filter3 = NULL;
@@ -142,7 +142,7 @@ inline CC* createCC(int nb_bits_bf){
 inline void initiateCC(CC* cc, int nb_bits_bf){
     ASSERT_NULL_PTR(cc,"createCC()")
 
-    cc->BF_filter2 = calloc((nb_bits_bf/SIZE_BITS_UINT_8T)+(SIZE_FILTER2_DEFAULT/SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    cc->BF_filter2 = (uint8_t*) calloc((nb_bits_bf/SIZE_BITS_UINT_8T)+(SIZE_FILTER2_DEFAULT/SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->BF_filter2,"createCC()")
 
     cc->filter3 = NULL;
@@ -213,7 +213,7 @@ inline void freeNode(Node* node, int lvl_node, info_per_level*  info_per_lvl){
 
 inline BFT_Root* createBFT_Root(int k, int treshold_compression, uint8_t compressed){
 
-    BFT_Root* root = malloc(sizeof(BFT_Root));
+    BFT_Root* root = (BFT_Root*) malloc(sizeof(BFT_Root));
     ASSERT_NULL_PTR(root,"createBFT_Root()")
 
     initialize_BFT_Root(root, k, treshold_compression, compressed);
@@ -293,7 +293,7 @@ inline BFT_Root* copy_BFT_Root(BFT_Root* root_src){
 
     ASSERT_NULL_PTR(root_src,"copy_BFT_Root()")
 
-    BFT_Root* root_dest = malloc(sizeof(BFT_Root));
+    BFT_Root* root_dest = (BFT_Root*) malloc(sizeof(BFT_Root));
     ASSERT_NULL_PTR(root_dest,"copy_BFT_Root()")
 
     memcpy(root_dest, root_src, sizeof(BFT_Root));
@@ -312,8 +312,8 @@ inline void add_genomes_BFT_Root(int nb_files, char** filenames, BFT_Root* root)
 
         ASSERT_NULL_PTR(filenames, "add_genomes_BFT_Root()\n")
 
-        if (root->filenames == NULL) root->filenames = malloc(nb_files * sizeof(char*));
-        else root->filenames = realloc(root->filenames, (root->nb_genomes + nb_files) * sizeof(char*));
+        if (root->filenames == NULL) root->filenames = (char**) malloc(nb_files * sizeof(char*));
+        else root->filenames = (char**) realloc(root->filenames, (root->nb_genomes + nb_files) * sizeof(char*));
 
         ASSERT_NULL_PTR(root->filenames, "add_genomes_BFT_Root()\n")
 
@@ -321,7 +321,7 @@ inline void add_genomes_BFT_Root(int nb_files, char** filenames, BFT_Root* root)
 
             ASSERT_NULL_PTR(filenames[i], "add_genomes_BFT_Root()\n")
 
-            root->filenames[i + root->nb_genomes] = calloc(strlen(filenames[i]) + 1, sizeof(char));
+            root->filenames[i + root->nb_genomes] = (char*) calloc(strlen(filenames[i]) + 1, sizeof(char));
             ASSERT_NULL_PTR(root->filenames[i + root->nb_genomes] , "add_genomes_BFT_Root()\n")
 
             strcpy(root->filenames[i + root->nb_genomes], filenames[i]);
@@ -340,7 +340,7 @@ inline void allocate_children_type (CC* cc, int nb_elt){
 
     ASSERT_NULL_PTR(cc, "allocate_children_type()")
 
-    cc->children_type = calloc(CEIL(nb_elt,2), sizeof(uint8_t));
+    cc->children_type = (uint8_t*) calloc(CEIL(nb_elt,2), sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->children_type, "allocate_children_type()")
 
     return;
@@ -375,7 +375,7 @@ inline uint8_t addNewElt(CC* cc, int position, int current_nb_elem, uint8_t type
 
             if ((cc->children_type[position/2] >> 4) + 1 == 0x10){
 
-                uint8_t* tmp_children_type = calloc(current_nb_elem, sizeof(uint8_t));
+                uint8_t* tmp_children_type = (uint8_t*) calloc(current_nb_elem, sizeof(uint8_t));
                 ASSERT_NULL_PTR(tmp_children_type, "addNewElt()")
 
                 int i, j;
@@ -398,7 +398,7 @@ inline uint8_t addNewElt(CC* cc, int position, int current_nb_elem, uint8_t type
         else{
             if ((cc->children_type[position/2] & 0xf) + 1 == 0x10){
 
-                uint8_t* tmp_children_type = calloc(current_nb_elem, sizeof(uint8_t));
+                uint8_t* tmp_children_type = (uint8_t*) calloc(current_nb_elem, sizeof(uint8_t));
                 ASSERT_NULL_PTR(tmp_children_type, "addNewElt()")
 
                 int i, j;
@@ -429,7 +429,7 @@ inline void realloc_and_int_children_type(CC* cc, int current_nb_elem, int posit
     ASSERT_NULL_PTR(cc, "realloc_and_int_children_type ()")
 
     if (type == 1){
-        cc->children_type = realloc(cc->children_type, (current_nb_elem+1)*sizeof(uint8_t));
+        cc->children_type = (uint8_t*) realloc(cc->children_type, (current_nb_elem+1)*sizeof(uint8_t));
         ASSERT_NULL_PTR(cc->children_type, "realloc_and_int_children_type ()")
 
         memmove(&(cc->children_type[position_insert+1]),
@@ -441,7 +441,7 @@ inline void realloc_and_int_children_type(CC* cc, int current_nb_elem, int posit
     else{
         if (IS_EVEN(current_nb_elem)){
 
-            cc->children_type = realloc(cc->children_type, (current_nb_elem / 2 + 1) * sizeof(uint8_t));
+            cc->children_type = (uint8_t*) realloc(cc->children_type, (current_nb_elem / 2 + 1) * sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->children_type, "realloc_and_int_children_type ()")
 
             cc->children_type[current_nb_elem / 2] = 0;

--- a/include/Node.h
+++ b/include/Node.h
@@ -160,7 +160,7 @@ inline uint64_t* create_hash_v_array(int rand_seed1, int rand_seed2){
     int j, nb_bits;
     uint32_t nb_hash_v = pow(4, NB_CHAR_SUF_PREF);
 
-    uint64_t* hash_v = malloc(nb_hash_v * 2 * sizeof(uint64_t));
+    uint64_t* hash_v = (uint64_t*) malloc(nb_hash_v * 2 * sizeof(uint64_t));
     ASSERT_NULL_PTR(hash_v, "create_hash_v_array()")
 
     uint8_t gen_sub[SIZE_BYTES_SUF_PREF];
@@ -192,7 +192,7 @@ inline uint64_t* create_hash_v_array(int rand_seed1, int rand_seed2){
 *  ---------------------------------------------------------------------------------------------------------------
 */
 inline Node* createNode(void){
-    Node* node = malloc(sizeof(Node));
+    Node* node = (Node*) malloc(sizeof(Node));
     ASSERT_NULL_PTR(node,"createNode()")
 
     node->CC_array = NULL;
@@ -221,7 +221,7 @@ inline void initiateNode(Node* node){
 
 inline resultPresence* create_resultPresence(){
 
-    resultPresence* res = calloc(1,sizeof(resultPresence));
+    resultPresence* res = (resultPresence*) calloc(1,sizeof(resultPresence));
     ASSERT_NULL_PTR(res,"create_resultPresence()")
 
     res->node = NULL;

--- a/include/UC.h
+++ b/include/UC.h
@@ -33,7 +33,7 @@ inline int max_size_annot_cplx_sub(uint8_t* annot_cplx, int nb_cplx, int size_cp
 
 inline UC* createUC(){
 
-    UC* uc = calloc(1,sizeof(UC));
+    UC* uc = (UC*) calloc(1,sizeof(UC));
     ASSERT_NULL_PTR(uc,"createUC()")
 
     uc->suffixes = NULL;
@@ -100,7 +100,7 @@ inline UC_SIZE_ANNOT_CPLX_T * min_size_per_annot_cplx(UC* uc, int nb_substrings,
     int pos = 0;
     int size_line = SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes;
 
-    UC_SIZE_ANNOT_CPLX_T *sizes = calloc(nb_substrings, sizeof( UC_SIZE_ANNOT_CPLX_T ));
+    UC_SIZE_ANNOT_CPLX_T *sizes = (UC_SIZE_ANNOT_CPLX_T*) calloc(nb_substrings, sizeof( UC_SIZE_ANNOT_CPLX_T ));
     ASSERT_NULL_PTR(sizes, "min_size_per_annot_cplx()")
 
     uint8_t* annot_cplx = &(uc->suffixes[nb_substrings * (size_substring + uc->size_annot)
@@ -134,7 +134,7 @@ inline UC_SIZE_ANNOT_CPLX_T * min_size_per_annot_cplx_sub(UC* uc, int nb_substri
 
     uint16_t pos = 0;
 
-    UC_SIZE_ANNOT_CPLX_T *sizes = calloc(pos_end - pos_start + 1, sizeof( UC_SIZE_ANNOT_CPLX_T ));
+    UC_SIZE_ANNOT_CPLX_T *sizes = (UC_SIZE_ANNOT_CPLX_T*) calloc(pos_end - pos_start + 1, sizeof( UC_SIZE_ANNOT_CPLX_T ));
     ASSERT_NULL_PTR(sizes, "min_size_per_annot_cplx_sub()")
 
     uint8_t* annot_cplx = &(uc->suffixes[nb_substrings * (size_substring + uc->size_annot)

--- a/include/annotation.h
+++ b/include/annotation.h
@@ -124,27 +124,27 @@ inline void free_annotation_array_elem(annotation_array_elem** annot_sorted, int
 
 inline annotation_inform* create_annotation_inform(int nb_id_genomes, bool disable_flag_0){
 
-    annotation_inform* ann_inf = calloc(1, sizeof(annotation_inform));
+    annotation_inform* ann_inf = (annotation_inform*) calloc(1, sizeof(annotation_inform));
     ASSERT_NULL_PTR(ann_inf,"create_annotation_inform()")
 
     if (nb_id_genomes <= 0){
-        ann_inf->id_stored = malloc(NB_MAX_ID_GENOMES * sizeof(uint32_t));
+        ann_inf->id_stored = (uint32_t*) malloc(NB_MAX_ID_GENOMES * sizeof(uint32_t));
         ASSERT_NULL_PTR(ann_inf->id_stored, "create_annotation_inform()");
 
-        ann_inf->size_id_stored = malloc(NB_MAX_ID_GENOMES * sizeof(uint32_t));
+        ann_inf->size_id_stored = (uint32_t*) malloc(NB_MAX_ID_GENOMES * sizeof(uint32_t));
         ASSERT_NULL_PTR(ann_inf->size_id_stored, "create_annotation_inform()");
 
-        ann_inf->annotation = calloc(SIZE_MAX_BYTE_ANNOT, sizeof(uint8_t));
+        ann_inf->annotation = (uint8_t*) calloc(SIZE_MAX_BYTE_ANNOT, sizeof(uint8_t));
         ASSERT_NULL_PTR(ann_inf->annotation, "create_annotation_inform()");
     }
     else{
-        ann_inf->id_stored = malloc(nb_id_genomes * sizeof(uint32_t));
+        ann_inf->id_stored = (uint32_t*) malloc(nb_id_genomes * sizeof(uint32_t));
         ASSERT_NULL_PTR(ann_inf->id_stored, "create_annotation_inform()");
 
-        ann_inf->size_id_stored = malloc(nb_id_genomes * sizeof(uint32_t));
+        ann_inf->size_id_stored = (uint32_t*) malloc(nb_id_genomes * sizeof(uint32_t));
         ASSERT_NULL_PTR(ann_inf->size_id_stored, "create_annotation_inform()");
 
-        ann_inf->annotation = calloc(CEIL(nb_id_genomes + 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+        ann_inf->annotation = (uint8_t*) calloc(CEIL(nb_id_genomes + 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
         ASSERT_NULL_PTR(ann_inf->annotation, "create_annotation_inform()");
     }
 
@@ -261,7 +261,7 @@ inline UC_SIZE_ANNOT_T *min_size_per_sub(uint8_t* annot, int nb_substrings, int 
     if (nb_substrings == 0) return 0;
     else ASSERT_NULL_PTR(annot, "min_size_per_sub()")
 
-    UC_SIZE_ANNOT_T *sizes = calloc(nb_substrings, sizeof( UC_SIZE_ANNOT_T ));
+    UC_SIZE_ANNOT_T *sizes = (UC_SIZE_ANNOT_T*) calloc(nb_substrings, sizeof( UC_SIZE_ANNOT_T ));
     ASSERT_NULL_PTR(sizes, "min_size_per_sub()")
 
     if (size_annot == 0) return sizes;

--- a/include/compression.h
+++ b/include/compression.h
@@ -73,7 +73,7 @@ typedef struct{
 
 inline Read_count* create_Read_count(){
 
-    Read_count* read_count = calloc(1, sizeof(Read_count));
+    Read_count* read_count = (Read_count*) calloc(1, sizeof(Read_count));
     ASSERT_NULL_PTR(read_count, "create_Read_count()\n");
 
     read_count->id_occ = NULL;
@@ -85,7 +85,7 @@ inline Read_count* create_Read_count(){
 
 inline Pos_length_occ* create_pos_length_occ(){
 
-    Pos_length_occ* pos_length_occ = calloc(1, sizeof(Pos_length_occ));
+    Pos_length_occ* pos_length_occ = (Pos_length_occ*) calloc(1, sizeof(Pos_length_occ));
     ASSERT_NULL_PTR(pos_length_occ, "create_Read_count()\n");
 
     pos_length_occ->id_occ = NULL;
@@ -113,7 +113,7 @@ inline void set_Pos_length_occ(Pos_length_occ* pos_length_occ, int pos, int leng
 inline Pos_length_occ* create_set_Pos_length_occ(int pos, int length, int occ_count, int rev, int nb_mismatches,
                                                  int64_t* id_occ, Mismatch* list_mismatches){
 
-    Pos_length_occ* pos_length_occ = malloc(sizeof(Pos_length_occ));
+    Pos_length_occ* pos_length_occ = (Pos_length_occ*) malloc(sizeof(Pos_length_occ));
     ASSERT_NULL_PTR(pos_length_occ, "binning_reads()\n")
 
     pos_length_occ->position = pos;
@@ -129,7 +129,7 @@ inline Pos_length_occ* create_set_Pos_length_occ(int pos, int length, int occ_co
 
 inline Pos_length_occ* create_set_Pos_length_occ_from_Read_count(int pos, int length, int rev, const Read_count* read_count){
 
-    Pos_length_occ* pos_length_occ = malloc(sizeof(Pos_length_occ));
+    Pos_length_occ* pos_length_occ = (Pos_length_occ*) malloc(sizeof(Pos_length_occ));
     ASSERT_NULL_PTR(pos_length_occ, "binning_reads()\n")
 
     pos_length_occ->position = pos;

--- a/src/CC.c
+++ b/src/CC.c
@@ -79,10 +79,10 @@ void transform2CC(UC*  uc, CC*  cc, BFT_Root* root, int lvl_cc, int size_suffix)
 
     int* new_order;
 
-    uint8_t* substrings = malloc(root->info_per_lvl[lvl_cc].nb_kmers_uc * SIZE_BYTES_SUF_PREF * sizeof(uint8_t));
+    uint8_t* substrings = (uint8_t*) malloc(root->info_per_lvl[lvl_cc].nb_kmers_uc * SIZE_BYTES_SUF_PREF * sizeof(uint8_t));
     ASSERT_NULL_PTR(substrings,"transform2CC()")
 
-    uint8_t* sub_equal = calloc(root->info_per_lvl[lvl_cc].nb_kmers_uc, sizeof(uint8_t));
+    uint8_t* sub_equal = (uint8_t*) calloc(root->info_per_lvl[lvl_cc].nb_kmers_uc, sizeof(uint8_t));
     ASSERT_NULL_PTR(sub_equal,"transform2CC()")
 
     UC_SIZE_ANNOT_T *annot_sizes = min_size_per_sub(uc->suffixes, root->info_per_lvl[lvl_cc].nb_kmers_uc, nb_cell, uc->size_annot);
@@ -161,13 +161,13 @@ void transform2CC(UC*  uc, CC*  cc, BFT_Root* root, int lvl_cc, int size_suffix)
                 z++;
             }
 
-            cc->children = realloc(cc->children, (it_children+1)*sizeof(UC));
+            cc->children = (UC*) realloc(cc->children, (it_children+1)*sizeof(UC));
             ASSERT_NULL_PTR(cc->children,"transform2CC()")
 
             uc_tmp = &(((UC*)cc->children)[it_children]);
             initializeUC(uc_tmp);
 
-            uc_tmp->suffixes = calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
+            uc_tmp->suffixes = (uint8_t*) calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
             ASSERT_NULL_PTR(uc_tmp->suffixes,"transform2CC()")
 
             uc_tmp->size_annot = k;
@@ -186,13 +186,13 @@ void transform2CC(UC*  uc, CC*  cc, BFT_Root* root, int lvl_cc, int size_suffix)
         z++;
     }
 
-    cc->children = realloc(cc->children, (it_children+1)*sizeof(UC));
+    cc->children = (UC*) realloc(cc->children, (it_children+1)*sizeof(UC));
     ASSERT_NULL_PTR(cc->children,"transform2CC()")
 
     uc_tmp = &(((UC*)cc->children)[it_children]);
     initializeUC(uc_tmp);
 
-    uc_tmp->suffixes = calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
+    uc_tmp->suffixes = (uint8_t*) calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
     ASSERT_NULL_PTR(uc_tmp->suffixes,"transform2CC()")
 
     uc_tmp->size_annot = k;
@@ -201,11 +201,11 @@ void transform2CC(UC*  uc, CC*  cc, BFT_Root* root, int lvl_cc, int size_suffix)
     k = -1;
 
     //Allocates memory for fields filter3 and extra_filter3 into the CC
-    cc->filter3 = malloc(nb_substrings_different*sizeof(uint8_t));
+    cc->filter3 = (uint8_t*) malloc(nb_substrings_different*sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->filter3,"transform2CC()")
 
     if (root->info_per_lvl[lvl_cc].level_min == 1){
-        cc->extra_filter3 = calloc(CEIL(nb_substrings_different, SIZE_BITS_UINT_8T),sizeof(uint8_t));
+        cc->extra_filter3 = (uint8_t*) calloc(CEIL(nb_substrings_different, SIZE_BITS_UINT_8T),sizeof(uint8_t));
         ASSERT_NULL_PTR(cc->extra_filter3,"transform2CC()")
     }
 
@@ -239,7 +239,7 @@ void transform2CC(UC*  uc, CC*  cc, BFT_Root* root, int lvl_cc, int size_suffix)
             //Update SkipFilter3 when a multiple of 248 unique prefix were inserted
             if (k % root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter3 == root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter3 - 1){
                 int new_size = (SIZE_FILTER2_DEFAULT/SIZE_BITS_UINT_8T)+((k+1)/root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter3);
-                cc->BF_filter2 = realloc(cc->BF_filter2, (size_bf+new_size)*sizeof(uint8_t));
+                cc->BF_filter2 = (uint8_t*) realloc(cc->BF_filter2, (size_bf+new_size)*sizeof(uint8_t));
                 cc->BF_filter2[size_bf+new_size-1] = (uint8_t)nb_1;
                 nb_1 = 0;
             }
@@ -396,16 +396,16 @@ void transform2CC_from_arraySuffix(uint8_t*  array_suffix, CC*  cc, BFT_Root* ro
     uint8_t bit_new_suf;
     uint8_t type = (cc->type >> 6) & 0x1;
 
-    uint8_t* substrings = malloc(root->info_per_lvl[lvl_cc].nb_kmers_uc*SIZE_BYTES_SUF_PREF*sizeof(uint8_t));
+    uint8_t* substrings = (uint8_t*) malloc(root->info_per_lvl[lvl_cc].nb_kmers_uc*SIZE_BYTES_SUF_PREF*sizeof(uint8_t));
     ASSERT_NULL_PTR(substrings, "transform2CC_from_arraySuffix()")
 
-    uint8_t* sub_equal = calloc(root->info_per_lvl[lvl_cc].nb_kmers_uc,sizeof(uint8_t));
+    uint8_t* sub_equal = (uint8_t*) calloc(root->info_per_lvl[lvl_cc].nb_kmers_uc,sizeof(uint8_t));
     ASSERT_NULL_PTR(sub_equal, "transform2CC_from_arraySuffix()")
 
     UC_SIZE_ANNOT_T *annot_sizes = min_size_per_sub(array_suffix, root->info_per_lvl[lvl_cc].nb_kmers_uc, nb_cell, size_annot);
     ASSERT_NULL_PTR(annot_sizes, "transform2CC_from_arraySuffix()")
 
-    UC_SIZE_ANNOT_CPLX_T *annot_sizes_cplx = calloc(root->info_per_lvl[lvl_cc].nb_kmers_uc,sizeof( UC_SIZE_ANNOT_CPLX_T ));
+    UC_SIZE_ANNOT_CPLX_T *annot_sizes_cplx = (UC_SIZE_ANNOT_CPLX_T *) calloc(root->info_per_lvl[lvl_cc].nb_kmers_uc,sizeof( UC_SIZE_ANNOT_CPLX_T ));
     ASSERT_NULL_PTR(annot_sizes_cplx, "transform2CC_from_arraySuffix()")
 
     int cmp = 0;
@@ -494,13 +494,13 @@ void transform2CC_from_arraySuffix(uint8_t*  array_suffix, CC*  cc, BFT_Root* ro
                 z++;
             }
 
-            cc->children = realloc(cc->children, (it_children+1)*sizeof(UC));
+            cc->children = (UC*) realloc(cc->children, (it_children+1)*sizeof(UC));
             ASSERT_NULL_PTR(cc->children,"transform2CC_from_arraySuffix()")
 
             uc = &(((UC*)cc->children)[it_children]);
             initializeUC(uc);
 
-            uc->suffixes = calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
+            uc->suffixes = (uint8_t*) calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
             ASSERT_NULL_PTR(uc->suffixes,"transform2CC_from_arraySuffix()")
 
             uc->size_annot = k;
@@ -519,13 +519,13 @@ void transform2CC_from_arraySuffix(uint8_t*  array_suffix, CC*  cc, BFT_Root* ro
         z++;
     }
 
-    cc->children = realloc(cc->children, (it_children+1)*sizeof(UC));
+    cc->children = (UC*) realloc(cc->children, (it_children+1)*sizeof(UC));
     ASSERT_NULL_PTR(cc->children,"transform2CC_from_arraySuffix()")
 
     uc = &(((UC*)cc->children)[it_children]);
     initializeUC(uc);
 
-    uc->suffixes = calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
+    uc->suffixes = (uint8_t*) calloc((i-begin_clust)*(nb_cell_children+k), sizeof(uint8_t));
     ASSERT_NULL_PTR(uc->suffixes,"transform2CC_from_arraySuffix()")
 
     uc->size_annot = k;
@@ -533,11 +533,11 @@ void transform2CC_from_arraySuffix(uint8_t*  array_suffix, CC*  cc, BFT_Root* ro
 
     k = -1;
 
-    cc->filter3 = malloc(nb_substrings_different*sizeof(uint8_t));
+    cc->filter3 = (uint8_t*) malloc(nb_substrings_different*sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->filter3,"transform2CC_from_arraySuffix()")
 
     if (root->info_per_lvl[lvl_cc].level_min == 1){
-        cc->extra_filter3 = calloc(CEIL(nb_substrings_different, SIZE_BITS_UINT_8T),sizeof(uint8_t));
+        cc->extra_filter3 = (uint8_t*) calloc(CEIL(nb_substrings_different, SIZE_BITS_UINT_8T),sizeof(uint8_t));
         ASSERT_NULL_PTR(cc->extra_filter3,"transform2CC_from_arraySuffix()")
     }
 
@@ -572,7 +572,7 @@ void transform2CC_from_arraySuffix(uint8_t*  array_suffix, CC*  cc, BFT_Root* ro
 
             if (k % root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter3 == root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter3 - 1){
                 int new_size = (SIZE_FILTER2_DEFAULT/SIZE_BITS_UINT_8T)+((k+1)/root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter3);
-                cc->BF_filter2 = realloc(cc->BF_filter2, (new_size+size_bf)*sizeof(uint8_t));
+                cc->BF_filter2 = (uint8_t*) realloc(cc->BF_filter2, (new_size+size_bf)*sizeof(uint8_t));
                 cc->BF_filter2[size_bf+new_size-1] = (uint8_t)nb_1;
                 nb_1 = 0;
             }
@@ -1169,11 +1169,11 @@ void insertSP_CC(resultPresence*  pres, BFT_Root* root, int lvl_node_insert,
 
     //Realloc the size of the list in the filter3
     if (suf==8){
-        cc->filter3 = realloc(cc->filter3, (cc->nb_elem+1)*sizeof(uint8_t));
+        cc->filter3 = (uint8_t*) realloc(cc->filter3, (cc->nb_elem+1)*sizeof(uint8_t));
         ASSERT_NULL_PTR(cc->filter3,"insertSP_CC()")
     }
     else if (cc->nb_elem%2 == 0){
-        cc->filter3 = realloc(cc->filter3, ((cc->nb_elem/2)+1)*sizeof(uint8_t));
+        cc->filter3 = (uint8_t*) realloc(cc->filter3, ((cc->nb_elem/2)+1)*sizeof(uint8_t));
         ASSERT_NULL_PTR(cc->filter3,"insertSP_CC()")
         cc->filter3[(cc->nb_elem/2)] = 0;
     }
@@ -1210,7 +1210,7 @@ void insertSP_CC(resultPresence*  pres, BFT_Root* root, int lvl_node_insert,
     if (info_per_lvl->level_min == 1){
         if (nb_cell_3rdlist*SIZE_BITS_UINT_8T == cc->nb_elem){
             nb_cell_3rdlist++;
-            cc->extra_filter3 = realloc(cc->extra_filter3, nb_cell_3rdlist*sizeof(uint8_t));
+            cc->extra_filter3 = (uint8_t*) realloc(cc->extra_filter3, nb_cell_3rdlist*sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->extra_filter3,"insertSP_CC()")
             cc->extra_filter3[nb_cell_3rdlist-1] = 0;
         }
@@ -1362,7 +1362,7 @@ void insertSP_CC(resultPresence*  pres, BFT_Root* root, int lvl_node_insert,
         if ((cc->nb_elem%info_per_lvl->nb_bits_per_cell_skip_filter3 == 0) && (cc->nb_elem >= info_per_lvl->nb_bits_per_cell_skip_filter3)){
 
             int new_cell = size_filter2_n_skip+(cc->nb_elem/info_per_lvl->nb_bits_per_cell_skip_filter3);
-            cc->BF_filter2 = realloc(cc->BF_filter2, new_cell*sizeof(uint8_t));
+            cc->BF_filter2 = (uint8_t*) realloc(cc->BF_filter2, new_cell*sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->BF_filter2,"insertSP_CC()")
             cc->BF_filter2[new_cell-1] = popcnt_8_par(cc->extra_filter3, nb_cell_3rdlist - info_per_lvl->nb_bytes_per_cell_skip_filter3, nb_cell_3rdlist);
         }
@@ -1421,7 +1421,7 @@ void insertSP_CC(resultPresence*  pres, BFT_Root* root, int lvl_node_insert,
 
             int new_cell = size_filter2_n_skip + cc->nb_elem / info_per_lvl->nb_bits_per_cell_skip_filter3;
 
-            cc->BF_filter2 = realloc(cc->BF_filter2, new_cell*sizeof(uint8_t));
+            cc->BF_filter2 = (uint8_t*) realloc(cc->BF_filter2, new_cell*sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->BF_filter2,"insertSP_CC()")
 
             tmp = new_cell-1;
@@ -1506,7 +1506,7 @@ void transform_Filter2n3(CC* cc, int pref_size, int suf_size, info_per_level*  i
 
     //Allocation of memory for the new filter 2, we can re-write on the filter 3 and extra filter 3
     //The order of suffixes stays the same in the Filter 3
-    uint8_t* filter2_tmp = calloc(size_filter2_n_skip+skip_filter_3, sizeof(uint8_t));
+    uint8_t* filter2_tmp = (uint8_t*) calloc(size_filter2_n_skip+skip_filter_3, sizeof(uint8_t));
     ASSERT_NULL_PTR(filter2_tmp,"transform_Filter2n3()")
 
     if (suf_size==4){
@@ -1649,8 +1649,8 @@ void transform_Filter2n3(CC* cc, int pref_size, int suf_size, info_per_level*  i
         }
 
         //Minimizes the memory required by the Filter 3
-        if (IS_ODD(cc->nb_elem)) cc->filter3 = realloc(cc->filter3, ((cc->nb_elem/2)+1)*sizeof(uint8_t));
-        else cc->filter3 = realloc(cc->filter3, (cc->nb_elem/2)*sizeof(uint8_t));
+        if (IS_ODD(cc->nb_elem)) cc->filter3 = (uint8_t*) realloc(cc->filter3, ((cc->nb_elem/2)+1)*sizeof(uint8_t));
+        else cc->filter3 = (uint8_t*) realloc(cc->filter3, (cc->nb_elem/2)*sizeof(uint8_t));
 
         ASSERT_NULL_PTR(cc->filter3,"transform_Filter2n3()")
 
@@ -1699,7 +1699,7 @@ int add_skp_annotation(CC* cc, int position_type, int size_annot, info_per_level
     int start = position_type/info_per_level->nb_ucs_skp;
 
     if (cc->nb_elem%info_per_level->nb_ucs_skp == 0){
-        cc->children = realloc(cc->children, nb_cell_skp*sizeof(UC));
+        cc->children = (UC*) realloc(cc->children, nb_cell_skp*sizeof(UC));
         ASSERT_NULL_PTR(cc->children, "add_skp_annotation()")
 
         uc = &(((UC*)cc->children)[nb_cell_skp-1]);
@@ -1720,7 +1720,7 @@ int add_skp_annotation(CC* cc, int position_type, int size_annot, info_per_level
 
             if (size_annot > uc->size_annot){
                 if (nb_children == 0){
-                    uc->suffixes = calloc(size_annot, sizeof(uint8_t));
+                    uc->suffixes = (uint8_t*) calloc(size_annot, sizeof(uint8_t));
                     uc->size_annot = size_annot;
                 }
                 else realloc_annotation(uc, 0, nb_children, size_annot, 1, position_child);
@@ -1734,13 +1734,13 @@ int add_skp_annotation(CC* cc, int position_type, int size_annot, info_per_level
 
                 if ((max_size_z > 0) && (uc->nb_extended_annot == 0) && (max_size_z < uc->size_annot)){
                     if (nb_children == 0){
-                        uc->suffixes = calloc(max_size_z, sizeof(uint8_t));
+                        uc->suffixes = (uint8_t*) calloc(max_size_z, sizeof(uint8_t));
                         uc->size_annot = max_size_z;
                     }
                     else realloc_annotation(uc, 0, nb_children, max_size_z, 1, position_child);
                 }
                 else {
-                    uc->suffixes = realloc(uc->suffixes, ((nb_children+1) * uc->size_annot + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
+                    uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((nb_children+1) * uc->size_annot + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                             + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes)) * sizeof(uint8_t));
                     ASSERT_NULL_PTR(uc->suffixes, "add_skp_annotation()")
 
@@ -1753,7 +1753,7 @@ int add_skp_annotation(CC* cc, int position_type, int size_annot, info_per_level
                 }
             }
             else {
-                uc->suffixes = realloc(uc->suffixes, ((nb_children + 1) * uc->size_annot + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((nb_children + 1) * uc->size_annot + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                         + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes)) * sizeof(uint8_t));
                 ASSERT_NULL_PTR(uc->suffixes, "add_skp_annotation()")
 
@@ -1821,7 +1821,7 @@ int add_skp_annotation(CC* cc, int position_type, int size_annot, info_per_level
 
             nb_children++;
 
-            uc->suffixes = realloc(uc->suffixes, ((nb_children * uc->size_annot) + (uc->nb_extended_annot + cpt) * SIZE_BYTE_EXT_ANNOT
+            uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((nb_children * uc->size_annot) + (uc->nb_extended_annot + cpt) * SIZE_BYTE_EXT_ANNOT
                                     + (uc->nb_cplx_nodes + cpt_cplx) * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes)) * sizeof(uint8_t));
             ASSERT_NULL_PTR(uc->suffixes, "add_skp_annotation()")
 
@@ -1888,7 +1888,7 @@ info_per_level* create_info_per_level(int size_max){
 
     for (i = NB_CHAR_SUF_PREF, nb_sizes = 0; i <= size_max; i += NB_CHAR_SUF_PREF, nb_sizes++){
 
-        ptr = realloc(ptr, (nb_sizes+1)*sizeof(info_per_level));
+        ptr = (info_per_level*) realloc(ptr, (nb_sizes+1)*sizeof(info_per_level));
         ASSERT_NULL_PTR(ptr,"create_info_per_level()")
 
         ptr[nb_sizes].nb_ucs_skp = NB_UC_PER_SKP;
@@ -2039,7 +2039,7 @@ void add_skp_children(CC* cc, int position_type, int position_child, int count_b
     int start = position_type/info_per_lvl->nb_ucs_skp;
 
     if (cc->nb_elem%info_per_lvl->nb_ucs_skp == 0){
-        cc->children = realloc(cc->children, nb_cell_skp*sizeof(UC));
+        cc->children = (UC*) realloc(cc->children, nb_cell_skp*sizeof(UC));
         ASSERT_NULL_PTR(cc->children, "add_skp_children()")
 
         uc = &(((UC*)cc->children)[nb_cell_skp-1]);
@@ -2056,7 +2056,7 @@ void add_skp_children(CC* cc, int position_type, int position_child, int count_b
 
             if (size_annot > uc->size_annot){
                 if (uc->nb_children == 0){
-                    uc->suffixes = calloc(size_substrings + size_annot, sizeof(uint8_t));
+                    uc->suffixes = (uint8_t*) calloc(size_substrings + size_annot, sizeof(uint8_t));
                     uc->size_annot = size_annot;
                 }
                 else realloc_annotation(uc, size_substrings, uc->nb_children, size_annot, 1, position_child);
@@ -2070,14 +2070,14 @@ void add_skp_children(CC* cc, int position_type, int position_child, int count_b
 
                 if ((max_size_z > 0) && (uc->nb_extended_annot == 0) && (max_size_z < uc->size_annot)){
                     if (uc->nb_children == 0){
-                        uc->suffixes = calloc(size_substrings + max_size_z, sizeof(uint8_t));
+                        uc->suffixes = (uint8_t*) calloc(size_substrings + max_size_z, sizeof(uint8_t));
                         uc->size_annot = max_size_z;
                     }
                     else realloc_annotation(uc, size_substrings, uc->nb_children, max_size_z, 1, position_child);
                 }
                 else {
                     size_line_children = size_substrings + uc->size_annot;
-                    uc->suffixes = realloc(uc->suffixes, ((uc->nb_children+1) * size_line_children + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
+                    uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((uc->nb_children+1) * size_line_children + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                                           + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes)) * sizeof(uint8_t));
                     ASSERT_NULL_PTR(uc->suffixes, "add_skp_children()")
 
@@ -2093,7 +2093,7 @@ void add_skp_children(CC* cc, int position_type, int position_child, int count_b
             }
             else {
                 size_line_children = size_substrings + uc->size_annot;
-                uc->suffixes = realloc(uc->suffixes, ((uc->nb_children + 1) * size_line_children + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((uc->nb_children + 1) * size_line_children + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                                       + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes)) * sizeof(uint8_t));
                 ASSERT_NULL_PTR(uc->suffixes, "add_skp_children()")
 
@@ -2184,7 +2184,7 @@ void add_skp_children(CC* cc, int position_type, int position_child, int count_b
 
                 uc->nb_children += count2push;
 
-                uc->suffixes = realloc(uc->suffixes,
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes,
                                     ((uc->nb_children * size_line_children) + (uc->nb_extended_annot + cpt_annot_extend_z) * SIZE_BYTE_EXT_ANNOT
                                      + (uc->nb_cplx_nodes + cpt_annot_cplx_z) * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes)) * sizeof(uint8_t));
                 ASSERT_NULL_PTR(uc->suffixes, "add_skp_children()")
@@ -2310,7 +2310,7 @@ uint16_t** build_skip_nodes(Node* node){
     while ((((CC*)node->CC_array)[node_nb_elem].type & 0x1) == 0) node_nb_elem++;
     node_nb_elem++;
 
-    nodes_skip = malloc(node_nb_elem*sizeof(uint16_t*));
+    nodes_skip = (uint16_t**) malloc(node_nb_elem*sizeof(uint16_t*));
     ASSERT_NULL_PTR(nodes_skip,"build_skip_nodes()")
 
     for (i=0; i<node_nb_elem; i++){
@@ -2318,7 +2318,7 @@ uint16_t** build_skip_nodes(Node* node){
         cc = &(((CC*)node->CC_array)[i]);
         nb_skp = cc->nb_elem / SIZE_CLUST_SKIP_NODES;
 
-        nodes_skip[i] = malloc(nb_skp*sizeof(uint16_t));
+        nodes_skip[i] = (uint16_t*) malloc(nb_skp*sizeof(uint16_t));
         ASSERT_NULL_PTR(nodes_skip[i],"build_skip_nodes()")
 
         for (j=0; j<nb_skp; j++){

--- a/src/UC.c
+++ b/src/UC.c
@@ -27,7 +27,7 @@ void insertKmer_UC(UC* uc, uint8_t*  kmer, uint32_t id_genome, int size_id_genom
 
     if (nb_elem == 0){
 
-        uc->suffixes = calloc(nb_cell + ann_inf->min_size, sizeof(uint8_t));
+        uc->suffixes = (uint8_t*) calloc(nb_cell + ann_inf->min_size, sizeof(uint8_t));
         ASSERT_NULL_PTR(uc->suffixes, "insertKmer_UC()")
 
         uc->nb_children = 0x2 | beginning_cluster;
@@ -50,7 +50,7 @@ void insertKmer_UC(UC* uc, uint8_t*  kmer, uint32_t id_genome, int size_id_genom
             beginning_cluster = uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                 + uc->nb_cplx_nodes * (uc->size_annot_cplx_nodes + SIZE_BYTE_CPLX_N);
 
-            uc->suffixes = realloc(uc->suffixes,
+            uc->suffixes = (uint8_t*) realloc(uc->suffixes,
                                    ((nb_elem+1) * size_line + beginning_cluster) * sizeof(uint8_t));
 
             memmove(&(uc->suffixes[(pos_insertion+1) * size_line]), &(uc->suffixes[pos_insertion * size_line]),
@@ -260,13 +260,13 @@ void get_annots(UC* uc, uint8_t*** annots, uint8_t*** annots_ext, uint8_t*** ann
     int i = 0;
     int nb_suffixes = position_end - position_start + 1;
 
-    *annots = malloc(nb_suffixes * sizeof(uint8_t*));
+    *annots = (uint8_t**) malloc(nb_suffixes * sizeof(uint8_t*));
     ASSERT_NULL_PTR(*annots, "get_annots()")
 
-    *size_annots_cplx = calloc(nb_suffixes, sizeof(int));
+    *size_annots_cplx = (int*) calloc(nb_suffixes, sizeof(int));
     ASSERT_NULL_PTR(*size_annots_cplx, "get_annots()")
 
-    *size_annots = calloc(nb_suffixes, sizeof(int));
+    *size_annots = (int*) calloc(nb_suffixes, sizeof(int));
     ASSERT_NULL_PTR(*size_annots, "get_annots()")
 
     *annots_ext = NULL;
@@ -485,13 +485,13 @@ void delete_extend_annots(UC* uc, int size_substring, int nb_substring, int pos_
                 ((nb_substring - pos_sub_end  - 1) * size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT + tot) * sizeof(uint8_t));
 
         if (realloc_table == 1){
-            uc->suffixes = realloc(uc->suffixes, ((nb_substring - (pos_sub_end - pos_sub_start + 1)) * size_line +
+            uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((nb_substring - (pos_sub_end - pos_sub_start + 1)) * size_line +
                                     uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT + tot) * sizeof(uint8_t));
             ASSERT_NULL_PTR(uc->suffixes,"delete_extend_annots()")
         }
     }
     else if (realloc_table == 1){
-        uc->suffixes = realloc(uc->suffixes, (nb_substring * size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT + tot) * sizeof(uint8_t));
+        uc->suffixes = (uint8_t*) realloc(uc->suffixes, (nb_substring * size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT + tot) * sizeof(uint8_t));
         ASSERT_NULL_PTR(uc->suffixes,"delete_extend_annots()")
     }
 
@@ -529,7 +529,7 @@ uint8_t** get_extend_annots(UC* uc, int size_substring, int nb_substring, int po
     uint8_t** ptr_extend_annot = NULL;
 
     if (uc->nb_extended_annot != 0){
-        ptr_extend_annot = malloc(count_sub*sizeof(uint8_t*));
+        ptr_extend_annot = (uint8_t**) malloc(count_sub*sizeof(uint8_t*));
         ASSERT_NULL_PTR(ptr_extend_annot,"get_extend_annots()")
 
         for (i = 0; i < count_sub; i++) ptr_extend_annot[i] = NULL;
@@ -575,7 +575,7 @@ void recopy_back_annot_extend(UC* uc, int size_substring, int nb_substring){
 
     uint8_t* new_suffixes;
 
-    new_suffixes = calloc(nb_substring * new_size_line + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes), sizeof(uint8_t));
+    new_suffixes = (uint8_t*) calloc(nb_substring * new_size_line + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes), sizeof(uint8_t));
     ASSERT_NULL_PTR(new_suffixes,"recopy_back_annot_extend()")
 
     for (i = 0, j = 0; i < nb_substring * new_size_line; i += new_size_line, j += old_size_line)
@@ -634,7 +634,7 @@ void create_annot_extended(UC* uc, int size_substring, int nb_substring){
     new_size_line = size_substring + uc->size_annot - 1;
     tot_new_size_line = nb_substring * new_size_line;
 
-    new_tab_suffixes = calloc(tot_new_size_line + nb_possible_annot_extend * SIZE_BYTE_EXT_ANNOT
+    new_tab_suffixes = (uint8_t*) calloc(tot_new_size_line + nb_possible_annot_extend * SIZE_BYTE_EXT_ANNOT
                               + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes), sizeof(uint8_t));
     ASSERT_NULL_PTR(new_tab_suffixes,"create_annot_extended()")
 
@@ -696,7 +696,7 @@ uint8_t* realloc_annotation(UC* uc, int size_substring, int nb_substring, int ne
 
         if (new_insertion == 1) new_size_line--;
 
-        new_tab_suffixes = calloc(((nb_substring + new_insertion) * new_size_line + new_insertion * SIZE_BYTE_EXT_ANNOT + tot_size_line_cplx), sizeof(uint8_t));
+        new_tab_suffixes = (uint8_t*) calloc(((nb_substring + new_insertion) * new_size_line + new_insertion * SIZE_BYTE_EXT_ANNOT + tot_size_line_cplx), sizeof(uint8_t));
         ASSERT_NULL_PTR(new_tab_suffixes,"realloc_annotation()")
 
         tot_size_line = nb_substring * old_size_line;
@@ -743,7 +743,7 @@ uint8_t* realloc_annotation(UC* uc, int size_substring, int nb_substring, int ne
             return realloc_annotation(uc, size_substring, nb_substring, new_size_annotation, new_insertion, pos_insert_extend);
         }
 
-        uc->suffixes = realloc(uc->suffixes, ((nb_substring + new_insertion) * old_size_line + (uc->nb_extended_annot+1) * SIZE_BYTE_EXT_ANNOT
+        uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((nb_substring + new_insertion) * old_size_line + (uc->nb_extended_annot+1) * SIZE_BYTE_EXT_ANNOT
                                 + tot_size_line_cplx) * sizeof(uint8_t));
         ASSERT_NULL_PTR(uc->suffixes,"realloc_annotation()")
 
@@ -831,7 +831,7 @@ uint8_t* realloc_annotation(UC* uc, int size_substring, int nb_substring, int ne
 
         if (new_insertion == 1){
 
-            uc->suffixes = realloc(uc->suffixes, ((nb_substring + 1) * old_size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
+            uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((nb_substring + 1) * old_size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                     + tot_size_line_cplx) * sizeof(uint8_t));
             ASSERT_NULL_PTR(uc->suffixes,"realloc_annotation()")
 
@@ -844,7 +844,7 @@ uint8_t* realloc_annotation(UC* uc, int size_substring, int nb_substring, int ne
     }
     else{
 
-        new_tab_suffixes = calloc(((nb_substring + new_insertion) * new_size_line + tot_size_line_cplx), sizeof(uint8_t));
+        new_tab_suffixes = (uint8_t*) calloc(((nb_substring + new_insertion) * new_size_line + tot_size_line_cplx), sizeof(uint8_t));
         ASSERT_NULL_PTR(new_tab_suffixes,"realloc_annotation()")
 
         if (new_insertion == 1){
@@ -1057,7 +1057,7 @@ void delete_annot_cplx_nodes(UC* uc, int size_substring, int nb_substring, int p
                  uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT + uc->nb_cplx_nodes * size_line_cplx_n) * sizeof(uint8_t));
 
         if (realloc_table == 1){
-            uc->suffixes = realloc(uc->suffixes,
+            uc->suffixes = (uint8_t*) realloc(uc->suffixes,
                                    ((nb_substring - (pos_sub_end - pos_sub_start + 1)) * size_line +
                                     uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT + uc->nb_cplx_nodes * size_line_cplx_n) * sizeof(uint8_t));
 
@@ -1065,7 +1065,7 @@ void delete_annot_cplx_nodes(UC* uc, int size_substring, int nb_substring, int p
         }
     }
     else if (realloc_table == 1){
-        uc->suffixes = realloc(uc->suffixes, (nb_substring * size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT +
+        uc->suffixes = (uint8_t*) realloc(uc->suffixes, (nb_substring * size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT +
                                               uc->nb_cplx_nodes * size_line_cplx_n) * sizeof(uint8_t));
 
         ASSERT_NULL_PTR(uc->suffixes,"delete_annot_cplx_nodes()")
@@ -1104,7 +1104,7 @@ uint8_t** get_annots_cplx_nodes(UC* uc, int size_substring, int nb_substring, in
     uint8_t** ptr_extend_annot = NULL;
 
     if (uc->nb_cplx_nodes != 0){
-        ptr_extend_annot = malloc(count_sub*sizeof(uint8_t*));
+        ptr_extend_annot = (uint8_t**) malloc(count_sub*sizeof(uint8_t*));
         ASSERT_NULL_PTR(ptr_extend_annot,"get_annots_cplx_nodes()")
 
         for (i=0; i<count_sub; i++) ptr_extend_annot[i] = NULL;
@@ -1147,7 +1147,7 @@ void recopy_back_annot_cplx_nodes(UC* uc, int size_substring, int nb_substring){
     int new_size_line = old_size_line + uc->size_annot_cplx_nodes;
     int tot_size_line = nb_substring * old_size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT;
 
-    uint8_t* new_suffixes = calloc(nb_substring * new_size_line,sizeof(uint8_t));
+    uint8_t* new_suffixes = (uint8_t*) calloc(nb_substring * new_size_line,sizeof(uint8_t));
     ASSERT_NULL_PTR(new_suffixes,"recopy_back_annot_cplx_nodes()")
 
     for (i=0; i<nb_substring; i++)
@@ -1195,7 +1195,7 @@ void increase_size_annot_cplx_nodes(UC* uc, int size_substring, int nb_substring
     uint8_t* cplx_n;
 
     if (to_realloc == 1){
-        uc->suffixes = realloc(uc->suffixes, (tot_size_line + uc->nb_cplx_nodes * size_line_cplx_n) * sizeof(uint8_t));
+        uc->suffixes = (uint8_t*) realloc(uc->suffixes, (tot_size_line + uc->nb_cplx_nodes * size_line_cplx_n) * sizeof(uint8_t));
         ASSERT_NULL_PTR(uc->suffixes, "increase_size_annot_cplx_nodes()")
     }
 
@@ -1237,7 +1237,7 @@ void decrease_size_annot_cplx_nodes(UC* uc, int size_substring, int nb_substring
         memset(&(cplx_n[i*size_line_cplx_n]), 0, size_line_cplx_n * sizeof(uint8_t));
     }
 
-    uc->suffixes = realloc(uc->suffixes, (tot_size_line + uc->nb_cplx_nodes * size_line_cplx_n) * sizeof(uint8_t));
+    uc->suffixes = (uint8_t*) realloc(uc->suffixes, (tot_size_line + uc->nb_cplx_nodes * size_line_cplx_n) * sizeof(uint8_t));
     ASSERT_NULL_PTR(uc->suffixes, "decrease_size_annot_cplx_nodes()")
 
     uc->size_annot_cplx_nodes = new_size;
@@ -1289,7 +1289,7 @@ void create_annot_cplx_nodes(UC* uc, int size_substring, int nb_substring){
     tot_new_size_line = nb_substring * size_substring;
     size_line_cplx_n = max_size_annot + SIZE_BYTE_CPLX_N;
 
-    new_tab_suffixes = calloc(tot_new_size_line + nb_possible_cplx_n * size_line_cplx_n, sizeof(uint8_t));
+    new_tab_suffixes = (uint8_t*) calloc(tot_new_size_line + nb_possible_cplx_n * size_line_cplx_n, sizeof(uint8_t));
     ASSERT_NULL_PTR(new_tab_suffixes,"create_annot_cplx_nodes()")
 
     extend_annot = &(new_tab_suffixes[tot_new_size_line]);
@@ -1384,7 +1384,7 @@ void create_annot_cplx_nodes(UC* uc, int size_substring, int nb_substring){
     tot_new_size_line = nb_substring * size_substring;
     size_line_cplx_n = max_size_annot + SIZE_BYTE_CPLX_N;
 
-    new_tab_suffixes = calloc(tot_new_size_line + nb_possible_cplx_n * size_line_cplx_n, sizeof(uint8_t));
+    new_tab_suffixes = (uint8_t*) calloc(tot_new_size_line + nb_possible_cplx_n * size_line_cplx_n, sizeof(uint8_t));
     ASSERT_NULL_PTR(new_tab_suffixes,"create_annot_cplx_nodes()")
 
     extend_annot = &(new_tab_suffixes[tot_new_size_line]);

--- a/src/annotation.c
+++ b/src/annotation.c
@@ -957,7 +957,7 @@ annotation_array_elem* sort_annotations(Pvoid_t* JArray_annot, int* size_array, 
     uint8_t it1_first_size;
     uint8_t it2_first_size;
 
-    uint8_t* it_index = malloc(tot_cell_index * sizeof(uint8_t));
+    uint8_t* it_index = (uint8_t*) malloc(tot_cell_index * sizeof(uint8_t));
     ASSERT_NULL_PTR(it_index, "sort_annotations()");
 
     uint8_t* first_index = NULL;
@@ -985,13 +985,13 @@ annotation_array_elem* sort_annotations(Pvoid_t* JArray_annot, int* size_array, 
 
         if (annot_list == NULL){
 
-            first_index = malloc((length_index + 1) * sizeof(uint8_t));
+            first_index = (uint8_t*) malloc((length_index + 1) * sizeof(uint8_t));
             ASSERT_NULL_PTR(first_index, "sort_annotations()");
 
             size_annot_list = real_size;
             *size_array = real_size;
 
-            annot_list = calloc(size_annot_list, sizeof(annotation_array_elem));
+            annot_list = (annotation_array_elem*) calloc(size_annot_list, sizeof(annotation_array_elem));
             ASSERT_NULL_PTR(annot_list, "sort_annotations()")
 
             for (tmp = 0; tmp < size_annot_list; tmp++){
@@ -1062,7 +1062,7 @@ annotation_array_elem* sort_annotations(Pvoid_t* JArray_annot, int* size_array, 
 
         pos_annot_list = size_annot_list-real_size;
         annot_list[pos_annot_list].size_annot = real_size;
-        annot_list[pos_annot_list].annot_array = calloc(size_annot_array, sizeof(uint8_t));
+        annot_list[pos_annot_list].annot_array = (uint8_t*) calloc(size_annot_array, sizeof(uint8_t));
 
         JSLL(PValue_annot, *JArray_annot, it_index);
 
@@ -1122,7 +1122,7 @@ annotation_array_elem* sort_annotations(Pvoid_t* JArray_annot, int* size_array, 
         annot_list[pos_annot_list].last_index = next_id - 1;
 
         JLFA(Rc_word, PArray_sizes);
-        //annot_list[pos_annot_list].annot_array = realloc(annot_list[pos_annot_list].annot_array, nb_annot_with_first_size * real_size * sizeof(uint8_t));
+        //annot_list[pos_annot_list].annot_array = (uint8_t*) realloc(annot_list[pos_annot_list].annot_array, nb_annot_with_first_size * real_size * sizeof(uint8_t));
 
         old_id = next_id;
     }
@@ -1161,7 +1161,7 @@ void sort_annotations2(char* filename_annot_array_elem, Pvoid_t* JArray_annot, a
 
     Pvoid_t PArray_sizes = (Pvoid_t) NULL;
 
-    annotation_array_elem* annot_list = calloc(1, sizeof(annotation_array_elem));
+    annotation_array_elem* annot_list = (annotation_array_elem*) calloc(1, sizeof(annotation_array_elem));
     ASSERT_NULL_PTR(annot_list, "sort_annotations()")
 
     int j;
@@ -1195,10 +1195,10 @@ void sort_annotations2(char* filename_annot_array_elem, Pvoid_t* JArray_annot, a
     uint8_t it1_first_size;
     uint8_t it2_first_size;
 
-    uint8_t* it_index = malloc(tot_cell_index * sizeof(uint8_t));
+    uint8_t* it_index = (uint8_t*) malloc(tot_cell_index * sizeof(uint8_t));
     ASSERT_NULL_PTR(it_index, "sort_annotations()");
 
-    uint8_t* first_index = calloc(tot_cell_index, sizeof(uint8_t));
+    uint8_t* first_index = (uint8_t*) calloc(tot_cell_index, sizeof(uint8_t));
     ASSERT_NULL_PTR(first_index, "sort_annotations()");
 
     uint8_t* it_index_tmp;
@@ -1291,7 +1291,7 @@ void sort_annotations2(char* filename_annot_array_elem, Pvoid_t* JArray_annot, a
 
         memcpy(it_index, first_index, (length_index + 1) * sizeof(uint8_t));
 
-        annot_list->annot_array = calloc(size_annot_array, sizeof(uint8_t));
+        annot_list->annot_array = (uint8_t*) calloc(size_annot_array, sizeof(uint8_t));
         ASSERT_NULL_PTR(annot_list->annot_array, "sort_annotations2()\n")
 
         JSLL(PValue_annot, *JArray_annot, it_index);
@@ -1425,10 +1425,10 @@ void sort_annotations3(Pvoid_t* JArray_annot, uint32_t longest_annot){
     uint8_t it1_first_size;
     uint8_t it2_first_size;
 
-    uint8_t* it_index = malloc(tot_cell_index * sizeof(uint8_t));
+    uint8_t* it_index = (uint8_t*) malloc(tot_cell_index * sizeof(uint8_t));
     ASSERT_NULL_PTR(it_index, "sort_annotations()");
 
-    uint8_t* first_index = calloc(tot_cell_index, sizeof(uint8_t));
+    uint8_t* first_index = (uint8_t*) calloc(tot_cell_index, sizeof(uint8_t));
     ASSERT_NULL_PTR(first_index, "sort_annotations()");
 
     memset(it_index, 0xff, tot_cell_index * sizeof(uint8_t));
@@ -1566,7 +1566,7 @@ void replace_annots_comp(annotation_array_elem* comp_colors, Pvoid_t* JArray_ann
     int file = open(filename_new_comp_colors, O_RDWR);
     if (file == -1) ERROR("replace_annots_comp()\n")
 
-    uint8_t* index = malloc(tot_cell_index * sizeof(uint8_t));
+    uint8_t* index = (uint8_t*) malloc(tot_cell_index * sizeof(uint8_t));
     ASSERT_NULL_PTR(index, "replace_annots_comp()\n");
 
     uint8_t* index_tmp;
@@ -1675,10 +1675,10 @@ void write_partial_comp_set_colors(char* filename_annot_array_elem, Pvoid_t* JAr
     int file = open(filename_annot_array_elem, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
     if (file == -1) ERROR("write_partial_comp_set_colors()\n")
 
-    uint8_t* index = malloc(tot_cell_index * sizeof(uint8_t));
+    uint8_t* index = (uint8_t*) malloc(tot_cell_index * sizeof(uint8_t));
     ASSERT_NULL_PTR(index, "write_partial_comp_set_colors()");
 
-    uint8_t* index_cpy = malloc(tot_cell_index * sizeof(uint8_t));
+    uint8_t* index_cpy = (uint8_t*) malloc(tot_cell_index * sizeof(uint8_t));
     ASSERT_NULL_PTR(index_cpy, "write_partial_comp_set_colors()");
 
     uint8_t* it_index_start;
@@ -1941,7 +1941,7 @@ void printAnnotation_CSV(FILE* file_output, uint8_t* annot, int size_annot, uint
 
     uint8_t* annot_real = annot;
 
-    uint8_t* annot_flag0 = calloc(size_annot_flag0, sizeof(uint8_t));
+    uint8_t* annot_flag0 = (uint8_t*) calloc(size_annot_flag0, sizeof(uint8_t));
     ASSERT_NULL_PTR(annot_flag0, "printAnnotation_CSV()")
 
     static const char* presence_genomes[16] = {"0,0,0,0,", "1,0,0,0,", "0,1,0,0,", "1,1,0,0,",
@@ -1971,7 +1971,7 @@ void printAnnotation_CSV(FILE* file_output, uint8_t* annot, int size_annot, uint
             annot_real = extract_from_annotation_array_elem(annot_sorted, position, &size);
         }
         else if (annot_sup != NULL){
-            annot_real = malloc(size*sizeof(uint8_t));
+            annot_real = (uint8_t*) malloc(size*sizeof(uint8_t));
             memcpy(annot_real, annot, size_annot*sizeof(uint8_t));
             annot_real[size_annot] = annot_sup[0];
         }
@@ -2183,7 +2183,7 @@ void get_id_genomes_from_annot(annotation_inform* ann_inf, annotation_array_elem
 
                 int nb_id_stored_cpy = 0;
 
-                uint32_t* id_stored_cpy = malloc(ann_inf->nb_id_stored * sizeof(uint32_t));
+                uint32_t* id_stored_cpy = (uint32_t*) malloc(ann_inf->nb_id_stored * sizeof(uint32_t));
                 ASSERT_NULL_PTR(id_stored_cpy, "get_id_genomes_from_annot()\n")
 
                 memcpy(id_stored_cpy, ann_inf->id_stored, ann_inf->nb_id_stored * sizeof(uint32_t));
@@ -2366,8 +2366,8 @@ annotation_array_elem* cmp_annots(uint8_t* annot1, int size_annot1, uint8_t* ann
     int size1 = size_annot1 + size_annot_sup1;
     int size2 = size_annot2 + size_annot_sup2;
 
-    uint8_t* annot1_flag0 = calloc(size_annot_flag0, sizeof(uint8_t));
-    uint8_t* annot2_flag0 = calloc(size_annot_flag0, sizeof(uint8_t));
+    uint8_t* annot1_flag0 = (uint8_t*) calloc(size_annot_flag0, sizeof(uint8_t));
+    uint8_t* annot2_flag0 = (uint8_t*) calloc(size_annot_flag0, sizeof(uint8_t));
 
     uint8_t* annot1_real = annot1;
     uint8_t* annot2_real = annot2;
@@ -2394,7 +2394,7 @@ annotation_array_elem* cmp_annots(uint8_t* annot1, int size_annot1, uint8_t* ann
             annot1_real = extract_from_annotation_array_elem(annot_sorted, position, &size1);
         }
         else if (annot_sup1 != NULL){
-            annot1_real = malloc(size1 * sizeof(uint8_t));
+            annot1_real = (uint8_t*) malloc(size1 * sizeof(uint8_t));
             memcpy(annot1_real, annot1, size_annot1 * sizeof(uint8_t));
             annot1_real[size_annot1] = annot_sup1[0];
         }
@@ -2424,7 +2424,7 @@ annotation_array_elem* cmp_annots(uint8_t* annot1, int size_annot1, uint8_t* ann
             annot2_real = extract_from_annotation_array_elem(annot_sorted, position, &size2);
         }
         else if (annot_sup2 != NULL){
-            annot2_real = malloc(size2 * sizeof(uint8_t));
+            annot2_real = (uint8_t*) malloc(size2 * sizeof(uint8_t));
             memcpy(annot2_real, annot2, size_annot2 * sizeof(uint8_t));
             annot2_real[size_annot2] = annot_sup2[0];
         }
@@ -2542,7 +2542,7 @@ annotation_array_elem* cmp_annots(uint8_t* annot1, int size_annot1, uint8_t* ann
     if ((annot1 != NULL) && ((annot1[0] & 0x3) != 3) && (annot_sup1 != NULL)) free(annot1_real);
     if ((annot2 != NULL) && ((annot2[0] & 0x3) != 3) && (annot_sup2 != NULL)) free(annot2_real);
 
-    annotation_array_elem* ann_arr_elem = malloc(sizeof(annotation_array_elem));
+    annotation_array_elem* ann_arr_elem = (annotation_array_elem*) malloc(sizeof(annotation_array_elem));
     ASSERT_NULL_PTR(ann_arr_elem, "intersection_annotations()");
 
     ann_arr_elem->annot_array = annot1_flag0;

--- a/src/bft.c
+++ b/src/bft.c
@@ -57,7 +57,7 @@ void insert_kmers_new_genome(int nb_kmers, char** kmers, char* genome_name, BFT*
 
             nb_bytes_kmer_comp = CEIL(bft->k * 2, SIZE_BITS_UINT_8T);
 
-            kmer_comp = malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
+            kmer_comp = (uint8_t*) malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
             ASSERT_NULL_PTR(kmer_comp,"insert_kmers_new_genome()\n")
 
             size_id_genome = get_nb_bytes_power2_annot(bft->nb_genomes-1);
@@ -98,7 +98,7 @@ void insert_kmers_last_genome(int nb_kmers, char** kmers, BFT* bft){
 
                 nb_bytes_kmer_comp = CEIL(bft->k * 2, SIZE_BITS_UINT_8T);
 
-                kmer_comp = malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
+                kmer_comp = (uint8_t*) malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
                 ASSERT_NULL_PTR(kmer_comp,"insert_kmers_last_genome()\n")
 
                 size_id_genome = get_nb_bytes_power2_annot(bft->nb_genomes-1);
@@ -132,13 +132,13 @@ BFT_kmer* create_kmer(const char* kmer, int k){
 
     if (strlen(kmer) != k) ERROR("create_kmer(): k-mer length is not the one used in the graph.\n")
 
-    BFT_kmer* bft_kmer = malloc(sizeof(BFT_kmer));
+    BFT_kmer* bft_kmer = (BFT_kmer*) malloc(sizeof(BFT_kmer));
     ASSERT_NULL_PTR(bft_kmer, "create_kmer()\n")
 
-    bft_kmer->kmer = malloc((k + 1) * sizeof(char));
+    bft_kmer->kmer = (char*) malloc((k + 1) * sizeof(char));
     ASSERT_NULL_PTR(bft_kmer->kmer, "create_kmer()\n")
 
-    bft_kmer->kmer_comp = calloc(CEIL(k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    bft_kmer->kmer_comp = (uint8_t*) calloc(CEIL(k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(bft_kmer->kmer_comp, "create_kmer()\n")
 
     memcpy(bft_kmer->kmer, kmer, k * sizeof(char));
@@ -146,7 +146,7 @@ BFT_kmer* create_kmer(const char* kmer, int k){
 
     if (parseKmerCount(bft_kmer->kmer, k, bft_kmer->kmer_comp, 0)){
 
-        bft_kmer->res = malloc(sizeof(resultPresence));
+        bft_kmer->res = (resultPresence*) malloc(sizeof(resultPresence));
         ASSERT_NULL_PTR(bft_kmer->res, "create_kmer()\n");
 
         initialize_resultPresence(bft_kmer->res);
@@ -162,7 +162,7 @@ BFT_kmer* create_kmer(const char* kmer, int k){
 */
 BFT_kmer* create_empty_kmer(){
 
-    BFT_kmer* bft_kmer = malloc(sizeof(BFT_kmer));
+    BFT_kmer* bft_kmer = (BFT_kmer*) malloc(sizeof(BFT_kmer));
     ASSERT_NULL_PTR(bft_kmer, "create_empty_kmer()\n")
 
     bft_kmer->kmer = NULL;
@@ -218,13 +218,13 @@ BFT_kmer* get_kmer(const char* kmer, BFT* bft){
     ASSERT_NULL_PTR(kmer, "get_kmer()\n")
     ASSERT_NULL_PTR(bft, "get_kmer()\n")
 
-    BFT_kmer* bft_kmer = malloc(sizeof(BFT_kmer));
+    BFT_kmer* bft_kmer = (BFT_kmer*) malloc(sizeof(BFT_kmer));
     ASSERT_NULL_PTR(bft_kmer, "isKmer_in_cdbg()\n")
 
-    bft_kmer->kmer = malloc((bft->k + 1) * sizeof(char));
+    bft_kmer->kmer = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(bft_kmer->kmer, "get_kmer()\n")
 
-    bft_kmer->kmer_comp = calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    bft_kmer->kmer_comp = (uint8_t*) calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(bft_kmer->kmer_comp, "get_kmer()\n")
 
     memcpy(bft_kmer->kmer, kmer, bft->k * sizeof(char));
@@ -325,7 +325,7 @@ size_t write_kmer_comp_to_disk(BFT_kmer* bft_kmer, BFT* bft, va_list args){
  /** Function creating an empty BFT_annotation. */
 inline BFT_annotation* create_BFT_annotation(){
 
-    BFT_annotation* bft_annot = malloc(sizeof(BFT_annotation));
+    BFT_annotation* bft_annot = (BFT_annotation*) malloc(sizeof(BFT_annotation));
     ASSERT_NULL_PTR(bft_annot, "create_BFT_annotation()\n")
 
     bft_annot->annot = NULL;
@@ -629,7 +629,7 @@ uint32_t* get_list_id_genomes(BFT_annotation* bft_annot, BFT* bft){
     get_id_genomes_from_annot(bft->ann_inf, bft->comp_set_colors, bft_annot->annot, bft_annot->size_annot,
                               bft_annot->annot_ext, size_annot_ext);
 
-    uint32_t* ids = malloc((bft->ann_inf->nb_id_stored + 1) * sizeof(uint32_t));
+    uint32_t* ids = (uint32_t*) malloc((bft->ann_inf->nb_id_stored + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(ids, "get_list_id_genomes()\n")
 
     ids[0] = bft->ann_inf->nb_id_stored;
@@ -665,7 +665,7 @@ uint32_t* intersection_list_id_genomes(uint32_t* list_a, uint32_t* list_b){
 
     uint32_t size_a = list_a[0]+1, size_b = list_b[0]+1;
 
-    uint32_t* list_c = malloc(MIN(size_a, size_b) * sizeof(uint32_t));
+    uint32_t* list_c = (uint32_t*) malloc(MIN(size_a, size_b) * sizeof(uint32_t));
     ASSERT_NULL_PTR(list_c, "intersection_list_id_genomes()\n")
 
     list_c[0] = 0;
@@ -811,9 +811,9 @@ BFT_kmer* get_neighbors(BFT_kmer* bft_kmer, BFT* bft){
         int lvl_root = (bft->k / NB_CHAR_SUF_PREF) - 1;
         int nb_bytes_kmer_comp = CEIL(bft->k * 2, SIZE_BITS_UINT_8T);
 
-        BFT_kmer* neighbors = malloc(8 * sizeof(BFT_kmer));
+        BFT_kmer* neighbors = (BFT_kmer*) malloc(8 * sizeof(BFT_kmer));
 
-        uint8_t* kmer_comp_tmp = malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
+        uint8_t* kmer_comp_tmp = (uint8_t*) malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
         ASSERT_NULL_PTR(kmer_comp_tmp, "get_neighbors()\n")
 
         memcpy(kmer_comp_tmp, bft_kmer->kmer_comp, nb_bytes_kmer_comp * sizeof(uint8_t));
@@ -822,15 +822,15 @@ BFT_kmer* get_neighbors(BFT_kmer* bft_kmer, BFT* bft){
 
         for (int i = 0; i < 4; i++){
 
-            neighbors[i].res = malloc(sizeof(resultPresence));
+            neighbors[i].res = (resultPresence*) malloc(sizeof(resultPresence));
             ASSERT_NULL_PTR(neighbors[i].res, "get_neighbors()\n")
 
             memcpy(neighbors[i].res, &(neigh_res[i]), sizeof(resultPresence));
 
-            neighbors[i].kmer = malloc((bft->k + 1) * sizeof(char));
+            neighbors[i].kmer = (char*) malloc((bft->k + 1) * sizeof(char));
             ASSERT_NULL_PTR(neighbors[i].kmer, "get_neighbors()\n")
 
-            neighbors[i].kmer_comp = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+            neighbors[i].kmer_comp = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
             ASSERT_NULL_PTR(neighbors[i].kmer_comp, "get_neighbors()\n")
 
             switch(i){
@@ -853,15 +853,15 @@ BFT_kmer* get_neighbors(BFT_kmer* bft_kmer, BFT* bft){
 
         for (int i = 4; i < 8; i++){
 
-            neighbors[i].res = malloc(sizeof(resultPresence));
+            neighbors[i].res = (resultPresence*) malloc(sizeof(resultPresence));
             ASSERT_NULL_PTR(neighbors[i].res, "get_neighbors()\n")
 
             memcpy(neighbors[i].res, &(neigh_res[i-4]), sizeof(resultPresence));
 
-            neighbors[i].kmer = malloc((bft->k + 1) * sizeof(char));
+            neighbors[i].kmer = (char*) malloc((bft->k + 1) * sizeof(char));
             ASSERT_NULL_PTR(neighbors[i].kmer, "get_neighbors()\n")
 
-            neighbors[i].kmer_comp = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+            neighbors[i].kmer_comp = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
             ASSERT_NULL_PTR(neighbors[i].kmer_comp, "get_neighbors()\n")
 
             memcpy(neighbors[i].kmer, &(bft_kmer->kmer[1]), (bft->k - 1) * sizeof(char));
@@ -900,9 +900,9 @@ BFT_kmer* get_predecessors(BFT_kmer* bft_kmer, BFT* bft){
         int lvl_root = (bft->k / NB_CHAR_SUF_PREF) - 1;
         int nb_bytes_kmer_comp = CEIL(bft->k * 2, SIZE_BITS_UINT_8T);
 
-        BFT_kmer* predecessors = malloc(4 * sizeof(BFT_kmer));
+        BFT_kmer* predecessors = (BFT_kmer*) malloc(4 * sizeof(BFT_kmer));
 
-        uint8_t* kmer_comp_tmp = malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
+        uint8_t* kmer_comp_tmp = (uint8_t*) malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
         ASSERT_NULL_PTR(kmer_comp_tmp, "get_predecessors()\n")
 
         memcpy(kmer_comp_tmp, bft_kmer->kmer_comp, nb_bytes_kmer_comp * sizeof(uint8_t));
@@ -911,15 +911,15 @@ BFT_kmer* get_predecessors(BFT_kmer* bft_kmer, BFT* bft){
 
         for (int i = 0; i < 4; i++){
 
-            predecessors[i].res = malloc(sizeof(resultPresence));
+            predecessors[i].res = (resultPresence*) malloc(sizeof(resultPresence));
             ASSERT_NULL_PTR(predecessors[i].res, "get_predecessors()\n")
 
             memcpy(predecessors[i].res, &(pred[i]), sizeof(resultPresence));
 
-            predecessors[i].kmer = malloc((bft->k + 1) * sizeof(char));
+            predecessors[i].kmer = (char*) malloc((bft->k + 1) * sizeof(char));
             ASSERT_NULL_PTR(predecessors[i].kmer, "get_predecessors()\n")
 
-            predecessors[i].kmer_comp = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+            predecessors[i].kmer_comp = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
             ASSERT_NULL_PTR(predecessors[i].kmer_comp, "get_predecessors()\n")
 
             switch(i){
@@ -958,9 +958,9 @@ BFT_kmer* get_successors(BFT_kmer* bft_kmer, BFT* bft){
         int lvl_root = (bft->k / NB_CHAR_SUF_PREF) - 1;
         int nb_bytes_kmer_comp = CEIL(bft->k * 2, SIZE_BITS_UINT_8T);
 
-        BFT_kmer* successors = malloc(4 * sizeof(BFT_kmer));
+        BFT_kmer* successors = (BFT_kmer*) malloc(4 * sizeof(BFT_kmer));
 
-        uint8_t* kmer_comp_tmp = malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
+        uint8_t* kmer_comp_tmp = (uint8_t*) malloc(nb_bytes_kmer_comp * sizeof(uint8_t));
         ASSERT_NULL_PTR(kmer_comp_tmp, "get_successors()\n")
 
         memcpy(kmer_comp_tmp, bft_kmer->kmer_comp, nb_bytes_kmer_comp * sizeof(uint8_t));
@@ -969,15 +969,15 @@ BFT_kmer* get_successors(BFT_kmer* bft_kmer, BFT* bft){
 
         for (int i = 0; i < 4; i++){
 
-            successors[i].res = malloc(sizeof(resultPresence));
+            successors[i].res = (resultPresence*) malloc(sizeof(resultPresence));
             ASSERT_NULL_PTR(successors[i].res, "get_successors()\n")
 
             memcpy(successors[i].res, &(succ[i]), sizeof(resultPresence));
 
-            successors[i].kmer = malloc((bft->k + 1) * sizeof(char));
+            successors[i].kmer = (char*) malloc((bft->k + 1) * sizeof(char));
             ASSERT_NULL_PTR(successors[i].kmer, "get_successors()\n")
 
-            successors[i].kmer_comp = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+            successors[i].kmer_comp = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
             ASSERT_NULL_PTR(successors[i].kmer_comp, "get_successors()\n")
 
             memcpy(successors[i].kmer, &(bft_kmer->kmer[1]), (bft->k - 1) * sizeof(char));
@@ -1018,15 +1018,15 @@ void v_iterate_over_kmers(BFT* bft, BFT_func_ptr f, va_list args){
     int nb_bytes_kmer_comp = CEIL(bft->k * 2, SIZE_BITS_UINT_8T);
     int lvl_root = (bft->k / NB_CHAR_SUF_PREF) - 1;
 
-    uint8_t* kmer = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+    uint8_t* kmer = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(kmer,"v_iterate_over_kmers()\n")
 
     BFT_kmer* bft_kmer = create_empty_kmer();
 
-    bft_kmer->kmer = malloc((bft->k + 1) * sizeof(char));
+    bft_kmer->kmer = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(bft_kmer->kmer, "v_iterate_over_kmers()\n")
 
-    bft_kmer->kmer_comp = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+    bft_kmer->kmer_comp = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(bft_kmer->kmer_comp, "v_iterate_over_kmers()\n")
 
     bft_kmer->res = create_resultPresence();
@@ -1059,15 +1059,15 @@ void iterate_over_kmers(BFT* bft, BFT_func_ptr f, ... ){
     int nb_bytes_kmer_comp = CEIL(bft->k * 2, SIZE_BITS_UINT_8T);
     int lvl_root = (bft->k / NB_CHAR_SUF_PREF) - 1;
 
-    uint8_t* kmer = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+    uint8_t* kmer = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(kmer,"iterate_over_kmers()\n")
 
     BFT_kmer* bft_kmer = create_empty_kmer();
 
-    bft_kmer->kmer = malloc((bft->k + 1) * sizeof(char));
+    bft_kmer->kmer = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(bft_kmer->kmer, "iterate_over_kmers()\n")
 
-    bft_kmer->kmer_comp = calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
+    bft_kmer->kmer_comp = (uint8_t*) calloc(nb_bytes_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(bft_kmer->kmer_comp, "iterate_over_kmers()\n")
 
     bft_kmer->res = create_resultPresence();
@@ -1111,18 +1111,18 @@ bool prefix_matching(BFT* bft, char* prefix, BFT_func_ptr f, ...){
 
     size_t return_value;
 
-    uint8_t* prefix_comp = calloc(size_kmer_comp, sizeof(uint8_t));
+    uint8_t* prefix_comp = (uint8_t*) calloc(size_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(prefix_comp, "prefix_matching()\n")
 
-    uint8_t* shifted_prefix_comp = malloc(size_kmer_comp * sizeof(uint8_t));
+    uint8_t* shifted_prefix_comp = (uint8_t*) malloc(size_kmer_comp * sizeof(uint8_t));
     ASSERT_NULL_PTR(shifted_prefix_comp, "prefix_matching()\n")
 
     BFT_kmer* bft_kmer = create_empty_kmer();
 
-    bft_kmer->kmer = malloc((bft->k + 1) * sizeof(char));
+    bft_kmer->kmer = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(bft_kmer->kmer, "prefix_matching()\n")
 
-    bft_kmer->kmer_comp = calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    bft_kmer->kmer_comp = (uint8_t*) calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(bft_kmer->kmer_comp, "prefix_matching()\n")
 
     bft_kmer->res = create_resultPresence();
@@ -1164,18 +1164,18 @@ bool prefix_matching_custom(BFT* bft, char* prefix, resultPresence** junction_pr
 
     size_t return_value;
 
-    uint8_t* prefix_comp = calloc(size_kmer_comp, sizeof(uint8_t));
+    uint8_t* prefix_comp = (uint8_t*) calloc(size_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(prefix_comp, "prefix_matching()\n")
 
-    uint8_t* shifted_prefix_comp = malloc(size_kmer_comp * sizeof(uint8_t));
+    uint8_t* shifted_prefix_comp = (uint8_t*) malloc(size_kmer_comp * sizeof(uint8_t));
     ASSERT_NULL_PTR(shifted_prefix_comp, "prefix_matching()\n")
 
     BFT_kmer* bft_kmer = create_empty_kmer();
 
-    bft_kmer->kmer = malloc((bft->k + 1) * sizeof(char));
+    bft_kmer->kmer = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(bft_kmer->kmer, "prefix_matching()\n")
 
-    bft_kmer->kmer_comp = calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    bft_kmer->kmer_comp = (uint8_t*) calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(bft_kmer->kmer_comp, "prefix_matching()\n")
 
     bft_kmer->res = create_resultPresence();
@@ -1259,15 +1259,15 @@ uint32_t* query_sequence(BFT* bft, char* sequence, double threshold, bool canoni
 
     uint32_t* colors_set;
 
-    uint32_t* count_colors = calloc(bft->nb_genomes, sizeof(uint32_t));
+    uint32_t* count_colors = (uint32_t*) calloc(bft->nb_genomes, sizeof(uint32_t));
     ASSERT_NULL_PTR(count_colors, "query_sequence()\n");
 
     char* kmer;
 
-    char* kmer_not_rev_comp = malloc((bft->k + 1) * sizeof(char));
+    char* kmer_not_rev_comp = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(kmer_not_rev_comp, "query_sequence()\n");
 
-    char* kmer_rev_comp = malloc((bft->k + 1) * sizeof(char));
+    char* kmer_rev_comp = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(kmer_rev_comp, "query_sequence()\n");
 
     kmer_not_rev_comp[bft->k] = '\0';
@@ -1319,7 +1319,7 @@ uint32_t* query_sequence(BFT* bft, char* sequence, double threshold, bool canoni
         if (nb_kmers_found + nb_kmers_colors_set - it_kmers_query < nb_kmers_query_min) break;
     }
 
-    colors_set = malloc((nb_colors + 1) * sizeof(uint32_t));
+    colors_set = (uint32_t*) malloc((nb_colors + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(colors_set, "query_sequence()\n");
 
     it_colors = 0;
@@ -1340,7 +1340,7 @@ uint32_t* query_sequence(BFT* bft, char* sequence, double threshold, bool canoni
 
     colors_set[0] = it_colors;
 
-    colors_set = realloc(colors_set, (it_colors + 1) * sizeof(uint32_t));
+    colors_set = (uint32_t*) realloc(colors_set, (it_colors + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(colors_set, "query_sequence()\n");
 
     free(kmer_not_rev_comp);
@@ -1379,10 +1379,10 @@ BFT* create_cdbg_from_bft_kmers(BFT_kmer** bft_kmers, uint32_t nb_bft_kmers, BFT
 
         //res = create_resultPresence();
 
-        substring = malloc(nb_bytes_kmer * sizeof(uint8_t));
+        substring = (uint8_t*) malloc(nb_bytes_kmer * sizeof(uint8_t));
         ASSERT_NULL_PTR(substring, "create_sub_cdbg()\n");
 
-        substring_tmp = malloc(nb_bytes_kmer * sizeof(uint8_t));
+        substring_tmp = (uint8_t*) malloc(nb_bytes_kmer * sizeof(uint8_t));
         ASSERT_NULL_PTR(substring_tmp, "create_sub_cdbg()\n");
 
         add_genomes_BFT_Root(bft->nb_genomes, bft->filenames, sub_bft);
@@ -1450,7 +1450,7 @@ BFT* create_cdbg_from_bft_kmers(BFT_kmer** bft_kmers, uint32_t nb_bft_kmers, BFT
     }
     else{
 
-        char** kmers = malloc(nb_bft_kmers * sizeof(char*));
+        char** kmers = (char**) malloc(nb_bft_kmers * sizeof(char*));
         ASSERT_NULL_PTR(kmers, "create_sub_cdbg()\n");
 
         for (i = 0; i < nb_bft_kmers; i++) kmers[i] = bft_kmers[i]->kmer;

--- a/src/branchingNode.c
+++ b/src/branchingNode.c
@@ -34,8 +34,8 @@ int isBranchingRight(Node*  node, BFT_Root* root, int lvl_node, uint8_t*  kmer, 
 
     __builtin_prefetch (info_per_lvl, 0, 0);
 
-    resultPresence* res = malloc(4*sizeof(resultPresence));
-    uint8_t* right_shifting = calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
+    resultPresence* res = (resultPresence*) malloc(4*sizeof(resultPresence));
+    uint8_t* right_shifting = (uint8_t*) calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
 
     ASSERT_NULL_PTR(res,"isBranchingRight()")
     ASSERT_NULL_PTR(right_shifting,"isBranchingRight()")
@@ -137,8 +137,8 @@ resultPresence* getRightNeighbors(Node*  node, BFT_Root* root, int lvl_node, uin
 
     __builtin_prefetch (info_per_lvl, 0, 0);
 
-    resultPresence* res = malloc(4 * sizeof(resultPresence));
-    uint8_t* right_shifting = calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
+    resultPresence* res = (resultPresence*) malloc(4 * sizeof(resultPresence));
+    uint8_t* right_shifting = (uint8_t*) calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
 
     ASSERT_NULL_PTR(res,"getRightNeighbors()")
     ASSERT_NULL_PTR(right_shifting,"getRightNeighbors()")
@@ -257,10 +257,10 @@ int isBranchingLeft(Node*  node, BFT_Root* root, int lvl_node, uint8_t*  kmer, i
 
     __builtin_prefetch (info_per_lvl, 0, 0);
 
-    resultPresence* res = malloc(4*sizeof(resultPresence));
+    resultPresence* res = (resultPresence*) malloc(4*sizeof(resultPresence));
     ASSERT_NULL_PTR(res,"isBranchingLeft()")
 
-    uint8_t* left_shifting = calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
+    uint8_t* left_shifting = (uint8_t*) calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
     ASSERT_NULL_PTR(left_shifting,"isBranchingLeft()")
 
     if (info_per_lvl->root == 1){
@@ -443,12 +443,12 @@ resultPresence* getLeftNeighbors(Node*  node, BFT_Root* root, int lvl_node, uint
     uint16_t nb_elt;
 
     resultPresence* res_tmp = NULL;
-    resultPresence* res = malloc(4*sizeof(resultPresence));
+    resultPresence* res = (resultPresence*) malloc(4*sizeof(resultPresence));
     ASSERT_NULL_PTR(res,"getLeftNeighbors()")
 
     __builtin_prefetch (info_per_lvl, 0, 0);
 
-    uint8_t* left_shifting = calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
+    uint8_t* left_shifting = (uint8_t*) calloc(info_per_lvl->size_kmer_in_bytes, sizeof(uint8_t));
     ASSERT_NULL_PTR(left_shifting,"getLeftNeighbors()")
 
     if (info_per_lvl->root == 1){
@@ -470,7 +470,7 @@ resultPresence* getLeftNeighbors(Node*  node, BFT_Root* root, int lvl_node, uint
     if (size_kmer == NB_CHAR_SUF_PREF){
         for (i=0; i < 4; i++){
             if (res[i].link_child != NULL){
-                res_tmp = malloc(sizeof(resultPresence));
+                res_tmp = (resultPresence*) malloc(sizeof(resultPresence));
                 memcpy(res_tmp, &(res[i]), sizeof(resultPresence));
                 break;
             }

--- a/src/compression.c
+++ b/src/compression.c
@@ -9,7 +9,7 @@ uint32_t compress_FASTx_files(char* filename_read_1, char* filename_read_2, bool
 
     int len_output_prefix = strlen(output_prefix);
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "min_simReads_max_simkmers() 2\n")
 
     strcpy(output_prefix_buffer, output_prefix);
@@ -52,7 +52,7 @@ void decompress_FASTx_file(char* output_prefix, bool pair_ended, int size_kmer, 
 
     int len_output_prefix = strlen(output_prefix);
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "min_simReads_max_simkmers() 2\n")
 
     strcpy(output_prefix_buffer, output_prefix);
@@ -120,7 +120,7 @@ size_t insert_kmer_into_bf(BloomFilter* bloom_filter, char* kmer, int length_kme
 
 BloomFilter* create_BloomFilter(uint64_t nb_elem, double fp_rate_max){
 
-    BloomFilter* bloom_filter = malloc(sizeof(BloomFilter));
+    BloomFilter* bloom_filter = (BloomFilter*) malloc(sizeof(BloomFilter));
     ASSERT_NULL_PTR(bloom_filter, "create_BloomFilter()\n")
 
     bloom_filter->size_block_bytes = SIZE_BLOCK_BYTES;
@@ -154,7 +154,7 @@ BloomFilter* create_BloomFilter(uint64_t nb_elem, double fp_rate_max){
     bloom_filter->seed_hash1 = rand();
     while (bloom_filter->seed_hash1 == (bloom_filter->seed_hash2 = rand())){};
 
-    bloom_filter->bf = calloc(bloom_filter->nb_bytes_bf, sizeof(uint8_t));
+    bloom_filter->bf = (uint8_t*) calloc(bloom_filter->nb_bytes_bf, sizeof(uint8_t));
     ASSERT_NULL_PTR(bloom_filter->bf,"create_BloomFilter()\n")
 
     return bloom_filter;
@@ -206,13 +206,13 @@ int64_t binning_reads(char* filename_reads_mate_1, char* filename_reads_mate_2, 
     char* info_read_non_rev = " 0";
     char* info_read_rev = " 1";
 
-    uint8_t* id_minimizer = malloc(size_minimizer_bytes * sizeof(uint8_t));
+    uint8_t* id_minimizer = (uint8_t*) malloc(size_minimizer_bytes * sizeof(uint8_t));
     ASSERT_NULL_PTR(id_minimizer, "binning_reads()\n")
 
-    char* bin_name = malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
+    char* bin_name = (char*) malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
     ASSERT_NULL_PTR(bin_name, "binning_reads()\n")
 
-    char* buffer_read_rev = malloc(length_buffer_read_rev * sizeof(char));
+    char* buffer_read_rev = (char*) malloc(length_buffer_read_rev * sizeof(char));
     ASSERT_NULL_PTR(buffer_read_rev, "binning_reads()\n")
 
     strcpy(bin_name, prefix_bin_name);
@@ -281,7 +281,7 @@ int64_t binning_reads(char* filename_reads_mate_1, char* filename_reads_mate_2, 
 
             length_buffer_read_rev = length_read + 1;
 
-            buffer_read_rev = realloc(buffer_read_rev, length_buffer_read_rev * sizeof(char));
+            buffer_read_rev = (char*) realloc(buffer_read_rev, length_buffer_read_rev * sizeof(char));
             ASSERT_NULL_PTR(buffer_read_rev, "binning_reads()\n")
         }
 
@@ -485,16 +485,16 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
     char* delimiter;
     char* read;
 
-    char* bin_name = malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
+    char* bin_name = (char*) malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
     ASSERT_NULL_PTR(bin_name, "binning_reads()\n")
 
-    char* buffer_read = malloc(size_buffer_read * sizeof(char));
+    char* buffer_read = (char*) malloc(size_buffer_read * sizeof(char));
     ASSERT_NULL_PTR(buffer_read, "binning_reads()\n")
 
-    char** array_reads = malloc(size_array_reads * sizeof(char*));
+    char** array_reads = (char**) malloc(size_array_reads * sizeof(char*));
     ASSERT_NULL_PTR(array_reads, "binning_reads()\n")
 
-    mis = malloc(nb_mis_max * sizeof(Mismatch));
+    mis = (Mismatch*) malloc(nb_mis_max * sizeof(Mismatch));
     ASSERT_NULL_PTR(mis, "binning_reads()\n")
 
     strcpy(bin_name, prefix_bin_name);
@@ -519,7 +519,7 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
                     delimiter[length_delimiter] = '\0';
                 }
 
-                read = malloc((length_delimiter + 1) * sizeof(char));
+                read = (char*) malloc((length_delimiter + 1) * sizeof(char));
                 ASSERT_NULL_PTR(read, "binning_reads()\n")
 
                 strcpy(read, delimiter);
@@ -553,7 +553,7 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
 
                     size_array_reads = list_count;
 
-                    array_reads = realloc(array_reads, size_array_reads * sizeof(char*));
+                    array_reads = (char**) realloc(array_reads, size_array_reads * sizeof(char*));
                     ASSERT_NULL_PTR(array_reads, "binning_reads()\n")
                 }
 
@@ -594,7 +594,7 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
 
                             if (match){
 
-                                read_count->list_mismatches = realloc(read_count->list_mismatches, (read_count->nb_mismatches + match) * sizeof(Mismatch));
+                                read_count->list_mismatches = (Mismatch*) realloc(read_count->list_mismatches, (read_count->nb_mismatches + match) * sizeof(Mismatch));
                                 ASSERT_NULL_PTR(read_count->list_mismatches, "binning_reads()\n")
 
                                 memcpy(&(read_count->list_mismatches[read_count->nb_mismatches]), mis, match * sizeof(Mismatch));
@@ -615,7 +615,7 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
                 }
                 else{
 
-                    read_count->id_occ = malloc(sizeof(int64_t));
+                    read_count->id_occ = (int64_t*) malloc(sizeof(int64_t));
                     ASSERT_NULL_PTR(read_count->id_occ, "binning_reads()\n")
 
                     delimiter = strchr(strchr(read_count->read, ' ') + 1, ' ');
@@ -644,14 +644,14 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
 
                             read_count->occ_count += 1;
 
-                            read_count->id_occ = realloc(read_count->id_occ, read_count->occ_count * sizeof(int64_t));
+                            read_count->id_occ = (int64_t*) realloc(read_count->id_occ, read_count->occ_count * sizeof(int64_t));
                             ASSERT_NULL_PTR(read_count->id_occ, "binning_reads()\n")
 
                             read_count->id_occ[read_count->occ_count - 1] = (int64_t) strtoll(delimiter, &delimiter, 10);
 
                             if (match){
 
-                                read_count->list_mismatches = realloc(read_count->list_mismatches, (read_count->nb_mismatches + match) * sizeof(Mismatch));
+                                read_count->list_mismatches = (Mismatch*) realloc(read_count->list_mismatches, (read_count->nb_mismatches + match) * sizeof(Mismatch));
                                 ASSERT_NULL_PTR(read_count->list_mismatches, "binning_reads()\n")
 
                                 memcpy(&(read_count->list_mismatches[read_count->nb_mismatches]), mis, match * sizeof(Mismatch));
@@ -668,7 +668,7 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
                             read_count->read = array_reads[it_list];
                             read_count->occ_count = 1;
 
-                            read_count->id_occ = malloc(sizeof(int64_t));
+                            read_count->id_occ = (int64_t*) malloc(sizeof(int64_t));
                             ASSERT_NULL_PTR(read_count->id_occ, "binning_reads()\n")
 
                             read_count->id_occ[0] = (int64_t) strtoll(delimiter, &delimiter, 10);
@@ -769,7 +769,7 @@ void create_super_reads(char* prefix_bin_name, bool pair_ended, int size_minimiz
 
                                 if (match){
 
-                                    pos_length_occ->list_mismatches = realloc(pos_length_occ->list_mismatches, (pos_length_occ->nb_mismatches + match) * sizeof(Mismatch));
+                                    pos_length_occ->list_mismatches = (Mismatch*) realloc(pos_length_occ->list_mismatches, (pos_length_occ->nb_mismatches + match) * sizeof(Mismatch));
                                     ASSERT_NULL_PTR(pos_length_occ->list_mismatches, "create_super_reads()\n")
 
                                     memcpy(&(pos_length_occ->list_mismatches[pos_length_occ->nb_mismatches]), mis, match * sizeof(Mismatch));
@@ -988,22 +988,22 @@ uint64_t create_spanning_super_reads(char* prefix_bin_name, bool pair_ended, int
 
     char* curr_minimizer;
 
-    uint8_t* id_minimizer = malloc(size_minimizer_bytes * sizeof(uint8_t));
+    uint8_t* id_minimizer = (uint8_t*) malloc(size_minimizer_bytes * sizeof(uint8_t));
     ASSERT_NULL_PTR(id_minimizer, "create_spanning_super_reads()\n")
 
-    char* bin_name = malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
+    char* bin_name = (char*) malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
     ASSERT_NULL_PTR(bin_name, "create_spanning_super_reads()\n")
 
-    char* buffer_read = malloc(size_buffer_read * sizeof(char));
+    char* buffer_read = (char*) malloc(size_buffer_read * sizeof(char));
     ASSERT_NULL_PTR(buffer_read, "create_spanning_super_reads()\n")
 
-    char* buffer_read_tmp = malloc(size_buffer_read_tmp * sizeof(char));
+    char* buffer_read_tmp = (char*) malloc(size_buffer_read_tmp * sizeof(char));
     ASSERT_NULL_PTR(buffer_read_tmp, "create_spanning_super_reads()\n")
 
-    char* buffer_read_rev = malloc(size_buffer_read_rev * sizeof(char));
+    char* buffer_read_rev = (char*) malloc(size_buffer_read_rev * sizeof(char));
     ASSERT_NULL_PTR(buffer_read_rev, "create_spanning_super_reads()\n")
 
-    Pos_length_occ** array_pos_length_occ = malloc(size_array_pos_length_occ * sizeof(Pos_length_occ*));
+    Pos_length_occ** array_pos_length_occ = (Pos_length_occ**) malloc(size_array_pos_length_occ * sizeof(Pos_length_occ*));
     ASSERT_NULL_PTR(array_pos_length_occ, "create_spanning_super_reads()\n")
 
     strcpy(bin_name, prefix_bin_name);
@@ -1132,7 +1132,7 @@ uint64_t create_spanning_super_reads(char* prefix_bin_name, bool pair_ended, int
 
                         size_buffer_read_rev = size_buffer_read;
 
-                        buffer_read_rev = realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
+                        buffer_read_rev = (char*) realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
                         ASSERT_NULL_PTR(buffer_read_rev, "create_spanning_super_reads()\n")
                     }
 
@@ -1276,7 +1276,7 @@ uint64_t create_spanning_super_reads(char* prefix_bin_name, bool pair_ended, int
 
                                                         size_buffer_read = length_read + length_read_tmp - pos_delimiter_read_tmp + 1;
 
-                                                        buffer_read = realloc(buffer_read, size_buffer_read * sizeof(char));
+                                                        buffer_read = (char*) realloc(buffer_read, size_buffer_read * sizeof(char));
                                                         ASSERT_NULL_PTR(buffer_read, "create_spanning_super_reads()\n")
                                                     }
 
@@ -1315,7 +1315,7 @@ uint64_t create_spanning_super_reads(char* prefix_bin_name, bool pair_ended, int
 
                                                     size_buffer_read_rev = size_buffer_read;
 
-                                                    buffer_read_rev = realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
+                                                    buffer_read_rev = (char*) realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
                                                     ASSERT_NULL_PTR(buffer_read_rev, "create_spanning_super_reads()\n")
                                                 }
 
@@ -1408,7 +1408,7 @@ uint64_t create_spanning_super_reads(char* prefix_bin_name, bool pair_ended, int
 
                                 size_array_pos_length_occ = list_count;
 
-                                array_pos_length_occ = realloc(array_pos_length_occ, size_array_pos_length_occ * sizeof(Pos_length_occ*));
+                                array_pos_length_occ = (Pos_length_occ**) realloc(array_pos_length_occ, size_array_pos_length_occ * sizeof(Pos_length_occ*));
                                 ASSERT_NULL_PTR(array_pos_length_occ, "binning_reads()\n")
                             }
 
@@ -1806,25 +1806,25 @@ uint64_t create_spanning_super_reads2(char* prefix_bin_name, bool pair_ended, in
 
     char* curr_minimizer;
 
-    uint8_t* id_minimizer = malloc(size_minimizer_bytes * sizeof(uint8_t));
+    uint8_t* id_minimizer = (uint8_t*) malloc(size_minimizer_bytes * sizeof(uint8_t));
     ASSERT_NULL_PTR(id_minimizer, "create_spanning_super_reads()\n")
 
-    char* bin_name = malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
+    char* bin_name = (char*) malloc((length_prefix_bin_name + size_minimizer + 100) * sizeof(char));
     ASSERT_NULL_PTR(bin_name, "create_spanning_super_reads()\n")
 
-    char* buffer_read = malloc(size_buffer_read * sizeof(char));
+    char* buffer_read = (char*) malloc(size_buffer_read * sizeof(char));
     ASSERT_NULL_PTR(buffer_read, "create_spanning_super_reads()\n")
 
-    char* buffer_read_tmp = malloc(size_buffer_read_tmp * sizeof(char));
+    char* buffer_read_tmp = (char*) malloc(size_buffer_read_tmp * sizeof(char));
     ASSERT_NULL_PTR(buffer_read_tmp, "create_spanning_super_reads()\n")
 
-    char* buffer_read_rev = malloc(size_buffer_read_rev * sizeof(char));
+    char* buffer_read_rev = (char*) malloc(size_buffer_read_rev * sizeof(char));
     ASSERT_NULL_PTR(buffer_read_rev, "create_spanning_super_reads()\n")
 
-    Pos_length_occ** array_pos_length_occ = malloc(size_array_pos_length_occ * sizeof(Pos_length_occ*));
+    Pos_length_occ** array_pos_length_occ = (Pos_length_occ**) malloc(size_array_pos_length_occ * sizeof(Pos_length_occ*));
     ASSERT_NULL_PTR(array_pos_length_occ, "create_spanning_super_reads()\n")
 
-    Mismatch* mis = malloc(nb_mis_max * sizeof(Mismatch));
+    Mismatch* mis = (Mismatch*) malloc(nb_mis_max * sizeof(Mismatch));
     ASSERT_NULL_PTR(mis, "binning_reads()\n")
 
     strcpy(bin_name, prefix_bin_name);
@@ -1953,7 +1953,7 @@ uint64_t create_spanning_super_reads2(char* prefix_bin_name, bool pair_ended, in
 
                         size_buffer_read_rev = size_buffer_read;
 
-                        buffer_read_rev = realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
+                        buffer_read_rev = (char*) realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
                         ASSERT_NULL_PTR(buffer_read_rev, "create_spanning_super_reads()\n")
                     }
 
@@ -2087,7 +2087,7 @@ uint64_t create_spanning_super_reads2(char* prefix_bin_name, bool pair_ended, in
 
                                                     if ((mis[it_id_occ].position >= pos_length_occ->position) && (mis[it_id_occ].position < pos_length_occ->position + pos_length_occ->length)){
 
-                                                        pos_length_occ->list_mismatches = realloc(pos_length_occ->list_mismatches, (pos_length_occ->nb_mismatches + 1) * sizeof(Mismatch));
+                                                        pos_length_occ->list_mismatches = (Mismatch*) realloc(pos_length_occ->list_mismatches, (pos_length_occ->nb_mismatches + 1) * sizeof(Mismatch));
                                                         ASSERT_NULL_PTR(pos_length_occ->list_mismatches, "create_spanning_super_reads()\n")
 
                                                         memcpy(&(pos_length_occ->list_mismatches[pos_length_occ->nb_mismatches]), &mis[it_id_occ], sizeof(Mismatch));
@@ -2112,7 +2112,7 @@ uint64_t create_spanning_super_reads2(char* prefix_bin_name, bool pair_ended, in
 
                                                     size_buffer_read = length_read + length_read_tmp - pos_delimiter_read_tmp + 1;
 
-                                                    buffer_read = realloc(buffer_read, size_buffer_read * sizeof(char));
+                                                    buffer_read = (char*) realloc(buffer_read, size_buffer_read * sizeof(char));
                                                     ASSERT_NULL_PTR(buffer_read, "create_spanning_super_reads()\n")
                                                 }
 
@@ -2151,7 +2151,7 @@ uint64_t create_spanning_super_reads2(char* prefix_bin_name, bool pair_ended, in
 
                                                 size_buffer_read_rev = size_buffer_read;
 
-                                                buffer_read_rev = realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
+                                                buffer_read_rev = (char*) realloc(buffer_read_rev, size_buffer_read_rev * sizeof(char));
                                                 ASSERT_NULL_PTR(buffer_read_rev, "create_spanning_super_reads()\n")
                                             }
 
@@ -2243,7 +2243,7 @@ uint64_t create_spanning_super_reads2(char* prefix_bin_name, bool pair_ended, in
 
                                 size_array_pos_length_occ = list_count;
 
-                                array_pos_length_occ = realloc(array_pos_length_occ, size_array_pos_length_occ * sizeof(Pos_length_occ*));
+                                array_pos_length_occ = (Pos_length_occ**) realloc(array_pos_length_occ, size_array_pos_length_occ * sizeof(Pos_length_occ*));
                                 ASSERT_NULL_PTR(array_pos_length_occ, "binning_reads()\n")
                             }
 
@@ -2567,7 +2567,7 @@ Pos_length_occ* parse_pos_length_occ(char** meta_to_parse, bool pair_ended){
 
     if (pair_ended){
 
-        pos_length_occ->id_occ = malloc(pos_length_occ->occ_count * sizeof(int64_t));
+        pos_length_occ->id_occ = (int64_t*) malloc(pos_length_occ->occ_count * sizeof(int64_t));
         ASSERT_NULL_PTR(pos_length_occ->id_occ, "parse_pos_length_occ()\n")
 
         for (int i = 0; i < pos_length_occ->occ_count; i++){
@@ -2578,7 +2578,7 @@ Pos_length_occ* parse_pos_length_occ(char** meta_to_parse, bool pair_ended){
 
     if (pos_length_occ->nb_mismatches){
 
-        pos_length_occ->list_mismatches = malloc(pos_length_occ->nb_mismatches * sizeof(Mismatch));
+        pos_length_occ->list_mismatches = (Mismatch*) malloc(pos_length_occ->nb_mismatches * sizeof(Mismatch));
         ASSERT_NULL_PTR(pos_length_occ->list_mismatches, "parse_pos_length_occ()\n")
 
         for (int i = 0; i < pos_length_occ->nb_mismatches; i++){
@@ -2692,18 +2692,18 @@ void reorder_reads(char* filename_src, char* filename_dest, int size_minimizer, 
 
     double first_reading = 0;
 
-    uint8_t* processed_reads = calloc(SIZE_BUFFER, sizeof(uint8_t));
+    uint8_t* processed_reads = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
     ASSERT_NULL_PTR(processed_reads, "reorder_reads()\n")
 
-    uint8_t* minimizers = calloc(SIZE_BUFFER, sizeof(char));
+    uint8_t* minimizers = (char*) calloc(SIZE_BUFFER, sizeof(char));
     ASSERT_NULL_PTR(minimizers, "reorder_reads()\n")
 
     char* curr_minimizer;
 
-    char* buffer_read = malloc(SIZE_BUFFER * sizeof(char));
+    char* buffer_read = (char*) malloc(SIZE_BUFFER * sizeof(char));
     ASSERT_NULL_PTR(buffer_read, "reorder_reads()\n")
 
-    char* buffer_read_rev = malloc(SIZE_BUFFER * sizeof(char));
+    char* buffer_read_rev = (char*) malloc(SIZE_BUFFER * sizeof(char));
     ASSERT_NULL_PTR(buffer_read_rev, "reorder_reads()\n")
 
     List* list_minimizers = List_create();
@@ -2732,7 +2732,7 @@ void reorder_reads(char* filename_src, char* filename_dest, int size_minimizer, 
             while (fgets(buffer_read, SIZE_BUFFER, file_reads_src) != NULL){
 
                 if (nb_read+1 > size_processed_reads){
-                    processed_reads = realloc(processed_reads, (size_processed_reads/SIZE_BITS_UINT_8T + SIZE_BUFFER) * sizeof(uint8_t));
+                    processed_reads = (uint8_t*) realloc(processed_reads, (size_processed_reads/SIZE_BITS_UINT_8T + SIZE_BUFFER) * sizeof(uint8_t));
                     ASSERT_NULL_PTR(processed_reads, "reorder_reads()\n")
 
                     memset(&processed_reads[size_processed_reads/SIZE_BITS_UINT_8T], 0 , SIZE_BUFFER * sizeof(uint8_t));
@@ -2742,7 +2742,7 @@ void reorder_reads(char* filename_src, char* filename_dest, int size_minimizer, 
 
                 if ((nb_read+1) * nb_bytes_minimizer > size_array_minimizers){
 
-                    minimizers = realloc(minimizers, (size_array_minimizers + SIZE_BUFFER) * sizeof(uint8_t));
+                    minimizers = (uint8_t*) realloc(minimizers, (size_array_minimizers + SIZE_BUFFER) * sizeof(uint8_t));
                     ASSERT_NULL_PTR(minimizers, "reorder_reads()\n")
 
                     memset(&minimizers[size_array_minimizers], 0, SIZE_BUFFER * sizeof(uint8_t));
@@ -2944,33 +2944,33 @@ void min_simReads_max_simkmers2(char* filename_read_1, char* filename_read_2, bo
         iterate_over_kmers(graph_no_iupac, insert_kmer_into_bf_from_graph, false, inserted_kmers);
     }
 
-    output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "min_simReads_max_simkmers() 2\n")
 
     strcpy(output_prefix_buffer, output_prefix);
 
-    buffer_read = malloc(size_buffer_read * sizeof(char));
+    buffer_read = (char*) malloc(size_buffer_read * sizeof(char));
     ASSERT_NULL_PTR(buffer_read, "min_simReads_max_simkmers() 7\n")
 
-    buffer_rev_comp = calloc(size_buffer_rev_comp, sizeof(char));
+    buffer_rev_comp = (char*) calloc(size_buffer_rev_comp, sizeof(char));
     ASSERT_NULL_PTR(buffer_rev_comp, "min_simReads_max_simkmers() 1\n")
 
-    buffer_kmer = malloc(SIZE_BUFFER * sizeof(char));
+    buffer_kmer = (char*) malloc(SIZE_BUFFER * sizeof(char));
     ASSERT_NULL_PTR(buffer_kmer, "min_simReads_max_simkmers() 12\n")
 
-    buffer_shift = malloc(SIZE_BUFFER * sizeof(char));
+    buffer_shift = (char*) malloc(SIZE_BUFFER * sizeof(char));
     ASSERT_NULL_PTR(buffer_shift, "min_simReads_max_simkmers() 13\n")
 
-    buffer_info_read = calloc(SIZE_BUFFER, sizeof(uint8_t));
+    buffer_info_read = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
     ASSERT_NULL_PTR(buffer_info_read, "min_simReads_max_simkmers() 16\n")
 
-    kmer = calloc(nb_bytes_iupac, sizeof(uint8_t));
+    kmer = (uint8_t*) calloc(nb_bytes_iupac, sizeof(uint8_t));
     ASSERT_NULL_PTR(kmer, "min_simReads_max_simkmers() 16\n")
 
-    hash_val = malloc(size_all_hash_val * sizeof(uint64_t));
+    hash_val = (uint64_t*) malloc(size_all_hash_val * sizeof(uint64_t));
     ASSERT_NULL_PTR(hash_val,"min_simReads_max_simkmers() 17\n")
 
-    hash_val_rev = malloc(size_all_hash_val * sizeof(uint64_t));
+    hash_val_rev = (uint64_t*) malloc(size_all_hash_val * sizeof(uint64_t));
     ASSERT_NULL_PTR(hash_val_rev,"min_simReads_max_simkmers() 18\n")
 
     strcpy(&(output_prefix_buffer[len_output_prefix]), "_span_sup_reads");
@@ -3010,10 +3010,10 @@ void min_simReads_max_simkmers2(char* filename_read_1, char* filename_read_2, bo
 
             size_all_hash_val = length_seq * 2;
 
-            hash_val = realloc(hash_val, size_all_hash_val * sizeof(uint64_t));
+            hash_val = (uint64_t*) realloc(hash_val, size_all_hash_val * sizeof(uint64_t));
             ASSERT_NULL_PTR(hash_val,"min_simReads_max_simkmers() 17\n")
 
-            hash_val_rev = realloc(hash_val_rev, size_all_hash_val * sizeof(uint64_t));
+            hash_val_rev = (uint64_t*) realloc(hash_val_rev, size_all_hash_val * sizeof(uint64_t));
             ASSERT_NULL_PTR(hash_val_rev,"min_simReads_max_simkmers() 18\n")
         }
 
@@ -3060,7 +3060,7 @@ void min_simReads_max_simkmers2(char* filename_read_1, char* filename_read_2, bo
 
                 size_buffer_rev_comp = size_buffer_read;
 
-                buffer_rev_comp = realloc(buffer_rev_comp, size_buffer_rev_comp * sizeof(char));
+                buffer_rev_comp = (char*) realloc(buffer_rev_comp, size_buffer_rev_comp * sizeof(char));
                 ASSERT_NULL_PTR(buffer_rev_comp, "min_simReads_max_simkmers() 20\n")
             }
 
@@ -3350,44 +3350,44 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
     bool first_kmers_part = true;
     bool last_kmers_part = true;
 
-    uint64_t* pref_part = calloc(1, sizeof(uint64_t));
-    uint64_t* suf_part = calloc(1, sizeof(uint64_t));
+    uint64_t* pref_part = (uint64_t*) calloc(1, sizeof(uint64_t));
+    uint64_t* suf_part = (uint64_t*) calloc(1, sizeof(uint64_t));
 
     uint64_t* union_pref_part = NULL;
 
     uint64_t** pref_suf;
 
-    uint8_t* kmers_iupac = malloc(nb_kmer_in_buf * nb_bytes_kmer_iupac * sizeof(uint8_t));
+    uint8_t* kmers_iupac = (uint8_t*) malloc(nb_kmer_in_buf * nb_bytes_kmer_iupac * sizeof(uint8_t));
     ASSERT_NULL_PTR(kmers_iupac, "compressKmers_from_KmerFiles()")
 
-    uint8_t* prefixes_iupac = calloc(nb_bytes_seed_iupac, sizeof(uint8_t));
+    uint8_t* prefixes_iupac = (uint8_t*) calloc(nb_bytes_seed_iupac, sizeof(uint8_t));
     ASSERT_NULL_PTR(prefixes_iupac, "compressKmers_from_KmerFiles()")
 
-    uint8_t* suffixes_iupac = calloc(nb_bytes_seed_iupac, sizeof(uint8_t));
+    uint8_t* suffixes_iupac = (uint8_t*) calloc(nb_bytes_seed_iupac, sizeof(uint8_t));
     ASSERT_NULL_PTR(suffixes_iupac, "compressKmers_from_KmerFiles()")
 
-    uint8_t* prev_suffix_iupac = calloc(nb_bytes_seed_iupac, sizeof(uint8_t));
+    uint8_t* prev_suffix_iupac = (uint8_t*) calloc(nb_bytes_seed_iupac, sizeof(uint8_t));
     ASSERT_NULL_PTR(prev_suffix_iupac, "compressKmers_from_KmerFiles()")
 
-    uint8_t* prefixes = calloc(nb_bytes_seed, sizeof(uint8_t));
+    uint8_t* prefixes = (uint8_t*) calloc(nb_bytes_seed, sizeof(uint8_t));
     ASSERT_NULL_PTR(prefixes, "compressKmers_from_KmerFiles()")
 
-    uint8_t* suffixes = calloc(nb_bytes_seed, sizeof(uint8_t));
+    uint8_t* suffixes = (uint8_t*) calloc(nb_bytes_seed, sizeof(uint8_t));
     ASSERT_NULL_PTR(suffixes, "compressKmers_from_KmerFiles()")
 
-    uint8_t* prefixes_in_partition = calloc(size_annot_seeds, sizeof(uint8_t));
+    uint8_t* prefixes_in_partition = (uint8_t*) calloc(size_annot_seeds, sizeof(uint8_t));
     ASSERT_NULL_PTR(prefixes_in_partition, "compressKmers_from_KmerFiles()")
 
-    uint8_t* suffixes_in_partition = calloc(size_annot_seeds, sizeof(uint8_t));
+    uint8_t* suffixes_in_partition = (uint8_t*) calloc(size_annot_seeds, sizeof(uint8_t));
     ASSERT_NULL_PTR(suffixes_in_partition, "compressKmers_from_KmerFiles()")
 
-    char* line = calloc(size_kmer + 1, sizeof(char));
+    char* line = (char*) calloc(size_kmer + 1, sizeof(char));
     ASSERT_NULL_PTR(line,"compressKmers_from_KmerFiles()")
 
-    char* seed_ASCII = calloc(size_seed + 1, sizeof(char));
+    char* seed_ASCII = (char*) calloc(size_seed + 1, sizeof(char));
     ASSERT_NULL_PTR(seed_ASCII, "compressKmers_from_KmerFiles()")
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "min_simReads_max_simkmers()")
 
     strcpy(output_prefix_buffer, output_prefix);
@@ -3537,7 +3537,7 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
 
                     pref_part[0]++;
 
-                    pref_part = realloc(pref_part, (pref_part[0]+1) * sizeof(uint64_t));
+                    pref_part = (uint64_t*) realloc(pref_part, (pref_part[0]+1) * sizeof(uint64_t));
                     ASSERT_NULL_PTR(pref_part, "compressKmers_from_KmerFiles_bis2()\n")
 
                     pref_part[pref_part[0]] = pref_iupac_tmp;
@@ -3574,7 +3574,7 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
                         fwrite(&recycled_partition, sizeof(uint32_t), 1, file_parts);
                         fwrite(suf_part, sizeof(uint32_t), 1, file_parts_count);
 
-                        pref_suf[0] = realloc(pref_suf[0], (pref_part[0] + pref_suf[0][0] + 1) * sizeof(uint64_t));
+                        pref_suf[0] = (uint64_t*) realloc(pref_suf[0], (pref_part[0] + pref_suf[0][0] + 1) * sizeof(uint64_t));
                         ASSERT_NULL_PTR(pref_suf[0], "compressKmers_from_KmerFiles_bis2()\n")
 
                         memcpy(&(pref_suf[0][pref_suf[0][0]+1]), &pref_part[1], pref_part[0] * sizeof(uint64_t));
@@ -3583,7 +3583,7 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
 
                         free(pref_part);
 
-                        pref_suf[1] = realloc(pref_suf[1], (suf_part[0] + pref_suf[1][0] + 1) * sizeof(uint64_t));
+                        pref_suf[1] = (uint64_t*) realloc(pref_suf[1], (suf_part[0] + pref_suf[1][0] + 1) * sizeof(uint64_t));
                         ASSERT_NULL_PTR(pref_suf[1], "compressKmers_from_KmerFiles_bis2()\n")
 
                         memcpy(&(pref_suf[1][pref_suf[1][0]+1]), &suf_part[1], suf_part[0] * sizeof(uint64_t));
@@ -3598,7 +3598,7 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
                         nb_recycled_part++;
                     }
                     else{
-                        pref_suf = malloc(2 * sizeof(uint64_t*));
+                        pref_suf = (uint64_t**) malloc(2 * sizeof(uint64_t*));
                         ASSERT_NULL_PTR(pref_suf, "compressKmers_from_KmerFiles_bis2()\n")
 
                         pref_suf[0] = pref_part;
@@ -3620,7 +3620,7 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
                     }
                 }
                 else{
-                    pref_suf = malloc(2 * sizeof(uint64_t*));
+                    pref_suf = (uint64_t**) malloc(2 * sizeof(uint64_t*));
                     ASSERT_NULL_PTR(pref_suf, "compressKmers_from_KmerFiles_bis2()\n")
 
                     pref_suf[0] = pref_part;
@@ -3642,8 +3642,8 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
                 }
 
                 first_kmers_part = true;
-                pref_part = calloc(1, sizeof(uint64_t));
-                suf_part = calloc(1, sizeof(uint64_t));
+                pref_part = (uint64_t*) calloc(1, sizeof(uint64_t));
+                suf_part = (uint64_t*) calloc(1, sizeof(uint64_t));
             }
 
             if (pref_iupac) JHSI(PValue, prefix_judy, prefixes_iupac, nb_bytes_seed_iupac)
@@ -3667,7 +3667,7 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
 
             pref_part[0]++;
 
-            pref_part = realloc(pref_part, (pref_part[0]+1) * sizeof(uint64_t));
+            pref_part = (uint64_t*) realloc(pref_part, (pref_part[0]+1) * sizeof(uint64_t));
             ASSERT_NULL_PTR(pref_part, "compressKmers_from_KmerFiles_bis2()\n")
 
             for (z = 0, pref_iupac_tmp = 0; z < nb_bytes_seed_iupac; z++)
@@ -3677,7 +3677,7 @@ uint32_t compressKmers_from_KmerFiles_bis2(char* output_prefix, int size_seed, i
 
             suf_part[0]++;
 
-            suf_part = realloc(suf_part, (suf_part[0]+1) * sizeof(uint64_t));
+            suf_part = (uint64_t*) realloc(suf_part, (suf_part[0]+1) * sizeof(uint64_t));
             ASSERT_NULL_PTR(suf_part, "compressKmers_from_KmerFiles_bis2()\n")
 
             for (z = 0, suf_iupac_tmp = 0; z < nb_bytes_seed_iupac; z++)
@@ -3819,34 +3819,34 @@ uint32_t compressKmers_from_KmerFiles_bis3(char* output_prefix, int size_seed, i
 
     uint8_t* partition_tmp;
 
-    uint8_t* kmers_iupac = malloc(nb_kmer_in_buf * nb_bytes_kmer_iupac * sizeof(uint8_t));
+    uint8_t* kmers_iupac = (uint8_t*) malloc(nb_kmer_in_buf * nb_bytes_kmer_iupac * sizeof(uint8_t));
     ASSERT_NULL_PTR(kmers_iupac, "compressKmers_from_KmerFiles()")
 
-    uint8_t* prefixes = calloc(nb_bytes_seed, sizeof(uint8_t));
+    uint8_t* prefixes = (uint8_t*) calloc(nb_bytes_seed, sizeof(uint8_t));
     ASSERT_NULL_PTR(prefixes, "compressKmers_from_KmerFiles()")
 
-    uint8_t* suffixes = calloc(nb_bytes_seed, sizeof(uint8_t));
+    uint8_t* suffixes = (uint8_t*) calloc(nb_bytes_seed, sizeof(uint8_t));
     ASSERT_NULL_PTR(suffixes, "compressKmers_from_KmerFiles()")
 
-    uint8_t* partition = calloc(size_annot_seeds, sizeof(uint8_t));
+    uint8_t* partition = (uint8_t*) calloc(size_annot_seeds, sizeof(uint8_t));
     ASSERT_NULL_PTR(partition, "compressKmers_from_KmerFiles()")
 
-    char* prefixes_iupac = calloc(size_seed + 1, sizeof(char));
+    char* prefixes_iupac = (char*) calloc(size_seed + 1, sizeof(char));
     ASSERT_NULL_PTR(prefixes_iupac, "compressKmers_from_KmerFiles()")
 
-    char* suffixes_iupac = calloc(size_seed + 1, sizeof(char));
+    char* suffixes_iupac = (char*) calloc(size_seed + 1, sizeof(char));
     ASSERT_NULL_PTR(suffixes_iupac, "compressKmers_from_KmerFiles()")
 
-    char* prev_suffix_iupac = calloc(size_seed + 1, sizeof(char));
+    char* prev_suffix_iupac = (char*) calloc(size_seed + 1, sizeof(char));
     ASSERT_NULL_PTR(prev_suffix_iupac, "compressKmers_from_KmerFiles()")
 
-    char* it_iupac = calloc(size_seed + 1, sizeof(char));
+    char* it_iupac = (char*) calloc(size_seed + 1, sizeof(char));
     ASSERT_NULL_PTR(it_iupac, "compressKmers_from_KmerFiles()")
 
-    char* line = calloc(size_kmer + 1, sizeof(char));
+    char* line = (char*) calloc(size_kmer + 1, sizeof(char));
     ASSERT_NULL_PTR(line,"compressKmers_from_KmerFiles()")
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "min_simReads_max_simkmers()")
 
     strcpy(output_prefix_buffer, output_prefix);
@@ -4040,7 +4040,7 @@ uint32_t compressKmers_from_KmerFiles_bis3(char* output_prefix, int size_seed, i
                     }
                     else{
 
-                        partition_all = malloc(2 * sizeof(void*));
+                        partition_all = (void**) malloc(2 * sizeof(void*));
                         ASSERT_NULL_PTR(partition_all, "compressKmers_from_KmerFiles()")
 
                         partition_all[0] = (void*) partition;
@@ -4068,7 +4068,7 @@ uint32_t compressKmers_from_KmerFiles_bis3(char* output_prefix, int size_seed, i
                 }
                 else{
 
-                    partition_all = malloc(2 * sizeof(void*));
+                    partition_all = (void**) malloc(2 * sizeof(void*));
                     ASSERT_NULL_PTR(partition_all, "compressKmers_from_KmerFiles()")
 
                     partition_all[0] = (void*) partition;
@@ -4096,7 +4096,7 @@ uint32_t compressKmers_from_KmerFiles_bis3(char* output_prefix, int size_seed, i
 
                 J1FA(Rc_word, pref_suf_pos);
 
-                partition = calloc(size_annot_seeds, sizeof(uint8_t));
+                partition = (uint8_t*) calloc(size_annot_seeds, sizeof(uint8_t));
                 ASSERT_NULL_PTR(partition, "compressKmers_from_KmerFiles()")
 
                 partition_iupac = NULL;
@@ -4355,7 +4355,7 @@ uint32_t* recycle_sub_paths(char* seed, uint32_t recycled_part, Pvoid_t* recycl_
 
     if (PValue == NULL){
 
-        array_pref_part_recycl = malloc(2 * sizeof(uint32_t));
+        array_pref_part_recycl = (uint32_t*) malloc(2 * sizeof(uint32_t));
         ASSERT_NULL_PTR(array_pref_part_recycl, "load_part_recycl()\n")
 
         array_pref_part_recycl[0] = 1;
@@ -4369,7 +4369,7 @@ uint32_t* recycle_sub_paths(char* seed, uint32_t recycled_part, Pvoid_t* recycl_
 
         array_pref_part_recycl[0]++;
 
-        array_pref_part_recycl = realloc(array_pref_part_recycl, (array_pref_part_recycl[0] + 1) * sizeof(uint32_t));
+        array_pref_part_recycl = (uint32_t*) realloc(array_pref_part_recycl, (array_pref_part_recycl[0] + 1) * sizeof(uint32_t));
         ASSERT_NULL_PTR(array_pref_part_recycl, "load_part_recycl()\n")
 
         array_pref_part_recycl[array_pref_part_recycl[0]] = recycled_part;
@@ -4407,13 +4407,13 @@ void serialize_subpaths_recycling(char* filename_subpaths_recycling, Pvoid_t* re
     uint64_t seed_iupac_tmp;
     uint64_t prev_seed_iupac = 0;
 
-    uint8_t* seed_comp = malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
+    uint8_t* seed_comp = (uint8_t*) malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_comp, "serialize_subpaths_recycling()\n")
 
-    uint8_t* seed_ascii = malloc((size_seed + 1) * sizeof(uint8_t));
+    uint8_t* seed_ascii = (uint8_t*) malloc((size_seed + 1) * sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_ascii, "serialize_subpaths_recycling()\n")
 
-    uint8_t* seed_present = calloc(size_seed_present, sizeof(uint8_t));
+    uint8_t* seed_present = (uint8_t*) calloc(size_seed_present, sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_present, "serialize_subpaths_recycling()\n")
 
     FILE* file_subpaths_recycling = fopen(filename_subpaths_recycling, "wb");
@@ -4545,28 +4545,28 @@ void insert_kmers_partitions2(char* output_prefix, int size_seed, int size_kmer,
 
     bool kmer_is_iupac;
 
-    char* seed = malloc((size_seed + 1) * sizeof(char));
+    char* seed = (char*) malloc((size_seed + 1) * sizeof(char));
     ASSERT_NULL_PTR(seed, "compressKmers_from_KmerFiles()")
 
-    char* seed_tmp = malloc((size_seed + 1) * sizeof(char));
+    char* seed_tmp = (char*) malloc((size_seed + 1) * sizeof(char));
     ASSERT_NULL_PTR(seed_tmp, "compressKmers_from_KmerFiles()")
 
-    char* ascii_kmer = malloc((size_kmer + 1) * sizeof(char));
+    char* ascii_kmer = (char*) malloc((size_kmer + 1) * sizeof(char));
     ASSERT_NULL_PTR(ascii_kmer, "compressKmers_from_KmerFiles()")
 
-    char* line = calloc(size_kmer + 1, sizeof(char));
+    char* line = (char*) calloc(size_kmer + 1, sizeof(char));
     ASSERT_NULL_PTR(line, "compressKmers_from_KmerFiles()")
 
-    uint8_t* kmers_iupac = malloc(nb_kmer_in_buf * nb_bytes_kmer_iupac * sizeof(uint8_t));
+    uint8_t* kmers_iupac = (uint8_t*) malloc(nb_kmer_in_buf * nb_bytes_kmer_iupac * sizeof(uint8_t));
     ASSERT_NULL_PTR(kmers_iupac, "compressKmers_from_KmerFiles()")
 
-    uint8_t* kmer_no_iupac = calloc(nb_bytes_kmer, sizeof(uint8_t));
+    uint8_t* kmer_no_iupac = (uint8_t*) calloc(nb_bytes_kmer, sizeof(uint8_t));
     ASSERT_NULL_PTR(kmer_no_iupac, "compressKmers_from_KmerFiles()")
 
-    uint8_t* substring = calloc(nb_bytes_kmer_iupac, sizeof(uint8_t));
+    uint8_t* substring = (uint8_t*) calloc(nb_bytes_kmer_iupac, sizeof(uint8_t));
     ASSERT_NULL_PTR(substring, "compressKmers_from_KmerFiles()")
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "min_simReads_max_simkmers()")
 
     //uint8_t mask_seed_iupac = SIZE_BITS_UINT_8T - ((size_seed % 2) * 4);
@@ -4836,12 +4836,12 @@ void insert_kmers_partitions2(char* output_prefix, int size_seed, int size_kmer,
                     if (inter_part != NULL){
 
                         if (kmer_is_iupac){
-                            kmer_tmp = malloc((nb_bytes_kmer_iupac + 1) * sizeof(uint8_t));
+                            kmer_tmp = (uint8_t*) malloc((nb_bytes_kmer_iupac + 1) * sizeof(uint8_t));
                             memcpy(&kmer_tmp[1], kmer, nb_bytes_kmer_iupac * sizeof(uint8_t));
                             kmer_tmp[0] = 0xff;
                         }
                         else{
-                            kmer_tmp = malloc((nb_bytes_kmer + 1) * sizeof(uint8_t));
+                            kmer_tmp = (uint8_t*) malloc((nb_bytes_kmer + 1) * sizeof(uint8_t));
                             memcpy(&kmer_tmp[1], kmer, nb_bytes_kmer * sizeof(uint8_t));
                             kmer_tmp[0] = 0x0;
                         }
@@ -5082,7 +5082,7 @@ void compress_annotations_BFT_disk(BFT_Root* bft, char* filename_bft){
     int len_longest_annot;
     int lvl_bft = (bft->k / NB_CHAR_SUF_PREF) - 1;
 
-    char* filename_bft_tmp = malloc((strlen(filename_bft) + 50) * sizeof(char));
+    char* filename_bft_tmp = (char*) malloc((strlen(filename_bft) + 50) * sizeof(char));
     ASSERT_NULL_PTR(filename_bft_tmp, "compress_annotations_BFT_disk()\n")
 
     strcpy(filename_bft_tmp, filename_bft);
@@ -5114,7 +5114,7 @@ void compress_annotations_BFT_disk(BFT_Root* bft, char* filename_bft){
     #if defined (_WORDx86)
         Word_t * PValue;
 
-        uint8_t* it_index = calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T - 1) + 4), sizeof(uint8_t));
+        uint8_t* it_index = (uint8_t*) calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T - 1) + 4), sizeof(uint8_t));
         ASSERT_NULL_PTR(it_index, "compressKmers_from_KmerFiles()\n");
 
         JSLF(PValue, comp_annots, it_index);
@@ -5177,10 +5177,10 @@ void create_subgraph_decomp(char* output_prefix, FILE* file_partitions, Pvoid_t*
 
     uint32_t nb_kmers = 0;
 
-    char* seed = calloc(size_seed * 2 + 1, sizeof(char));
+    char* seed = (char*) calloc(size_seed * 2 + 1, sizeof(char));
     ASSERT_NULL_PTR(seed, "create_subgraph_decomp()\n")
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "create_subgraph_decomp()\n")
 
     strcpy(output_prefix_buffer, output_prefix);
@@ -5317,7 +5317,7 @@ size_t load_subgraph(BFT_kmer* kmer, BFT* graph, va_list args){
 
     JSLG(PValue, *prefix_part_recycl, (uint8_t*)seed);
 
-    list_part_recycl = malloc((list_kmer_partitions[0] + 1) * sizeof(uint32_t));
+    list_part_recycl = (uint32_t*) malloc((list_kmer_partitions[0] + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(list_part_recycl, "load_subgraph()\n")
 
     list_part_recycl[0] = 0;
@@ -5384,7 +5384,7 @@ size_t load_subgraph(BFT_kmer* kmer, BFT* graph, va_list args){
             nb_cell = new_graph->info_per_lvl[lvl_suffix].size_kmer_in_bytes;
             nb_bytes_kmer = CEIL(new_graph->k * 2, SIZE_BITS_UINT_8T);
 
-            substring = malloc(nb_bytes_kmer * sizeof(uint8_t));
+            substring = (uint8_t*) malloc(nb_bytes_kmer * sizeof(uint8_t));
             ASSERT_NULL_PTR(substring, "kmer_has_partition()\n")
 
             memcpy(substring, kmer->kmer_comp, nb_bytes_kmer * sizeof(uint8_t));
@@ -5553,7 +5553,7 @@ void cdbg_traverse_overlap_insert(BFT* bft_no_iupac, BFT* bft_iupac, BFT* insert
 
         if (is_substring_IUPAC(overlap)){
 
-            overlap_comp = calloc(size_overlap_comp, sizeof(uint8_t));
+            overlap_comp = (uint8_t*) calloc(size_overlap_comp, sizeof(uint8_t));
             ASSERT_NULL_PTR(overlap_comp, "cdbg_traverse_overlap_insert()\n")
 
             parseKmerCount_IUPAC(overlap, length_overlap, overlap_comp, 0);
@@ -5578,7 +5578,7 @@ void cdbg_traverse_overlap_insert(BFT* bft_no_iupac, BFT* bft_iupac, BFT* insert
 
             if (!kmer_has_partition){
 
-                overlap_comp = calloc(size_overlap_comp, sizeof(uint8_t));
+                overlap_comp = (uint8_t*) calloc(size_overlap_comp, sizeof(uint8_t));
                 ASSERT_NULL_PTR(overlap_comp, "cdbg_traverse_overlap_insert()\n")
 
                 parseKmerCount_IUPAC(overlap, length_overlap, overlap_comp, 0);
@@ -5614,10 +5614,10 @@ bool cdbg_get_successor_overlap(BFT* bft, bool graph_is_iupac, char** overlap, u
 
         int length_overlap = strlen(*overlap);
 
-        char* overlap_no_iupac = malloc((bft->k + 1) * sizeof(char));
+        char* overlap_no_iupac = (char*) malloc((bft->k + 1) * sizeof(char));
         ASSERT_NULL_PTR(overlap_no_iupac, "cdbg_get_successor_overlap()\n")
 
-        uint8_t* overlap_comp = calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+        uint8_t* overlap_comp = (uint8_t*) calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
         ASSERT_NULL_PTR(overlap_comp, "cdbg_get_successor_overlap()\n")
 
         parseKmerCount_IUPAC(*overlap, length_overlap, overlap_comp, 0);
@@ -5628,7 +5628,7 @@ bool cdbg_get_successor_overlap(BFT* bft, bool graph_is_iupac, char** overlap, u
 
         if (kmer_has_partition_bool){
 
-            *overlap = realloc(*overlap, (bft->k / 2 + 1) * sizeof(char));
+            *overlap = (char*) realloc(*overlap, (bft->k / 2 + 1) * sizeof(char));
             ASSERT_NULL_PTR(*overlap, "cdbg_get_successor_overlap()\n")
 
             parseKmerCount(overlap_no_iupac, bft->k, overlap_comp, 0);
@@ -5641,7 +5641,7 @@ bool cdbg_get_successor_overlap(BFT* bft, bool graph_is_iupac, char** overlap, u
     }
     else{
 
-        *overlap = realloc(*overlap, (bft->k + 1) * sizeof(char));
+        *overlap = (char*) realloc(*overlap, (bft->k + 1) * sizeof(char));
         ASSERT_NULL_PTR(*overlap, "cdbg_get_successor_overlap()\n")
 
         prefix_matching(bft, *overlap, kmer_has_partition, *overlap, partition, &kmer_has_partition_bool);
@@ -5662,10 +5662,10 @@ bool cdbg_get_successor_overlap_custom(BFT* bft, bool graph_is_iupac, char** ove
 
         int length_overlap = strlen(*overlap);
 
-        char* overlap_no_iupac = malloc((bft->k + 1) * sizeof(char));
+        char* overlap_no_iupac = (char*) malloc((bft->k + 1) * sizeof(char));
         ASSERT_NULL_PTR(overlap_no_iupac, "cdbg_get_successor_overlap()\n")
 
-        uint8_t* overlap_comp = calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+        uint8_t* overlap_comp = (uint8_t*) calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
         ASSERT_NULL_PTR(overlap_comp, "cdbg_get_successor_overlap()\n")
 
         parseKmerCount_IUPAC(*overlap, length_overlap, overlap_comp, 0);
@@ -5676,7 +5676,7 @@ bool cdbg_get_successor_overlap_custom(BFT* bft, bool graph_is_iupac, char** ove
 
         if (kmer_has_partition_bool){
 
-            *overlap = realloc(*overlap, (bft->k / 2 + 1) * sizeof(char));
+            *overlap = (char*) realloc(*overlap, (bft->k / 2 + 1) * sizeof(char));
             ASSERT_NULL_PTR(*overlap, "cdbg_get_successor_overlap()\n")
 
             parseKmerCount(overlap_no_iupac, bft->k, overlap_comp, 0);
@@ -5689,7 +5689,7 @@ bool cdbg_get_successor_overlap_custom(BFT* bft, bool graph_is_iupac, char** ove
     }
     else{
 
-        *overlap = realloc(*overlap, (bft->k + 1) * sizeof(char));
+        *overlap = (char*) realloc(*overlap, (bft->k + 1) * sizeof(char));
         ASSERT_NULL_PTR(*overlap, "cdbg_get_successor_overlap()\n")
 
         prefix_matching_custom(bft, *overlap, junction_overlap, kmer_has_partition, *overlap, partition, &kmer_has_partition_bool);
@@ -5744,7 +5744,7 @@ size_t insert_kmer_with_partition(BFT_kmer* kmer, BFT* graph, va_list args){
             int nb_cell = bft_to_insert->info_per_lvl[lvl_bft_to_insert].size_kmer_in_bytes;
             int nb_bytes_kmer = CEIL(bft_to_insert->k * 2, SIZE_BITS_UINT_8T);
 
-            uint8_t* substring = malloc(nb_bytes_kmer * sizeof(uint8_t));
+            uint8_t* substring = (uint8_t*) malloc(nb_bytes_kmer * sizeof(uint8_t));
             ASSERT_NULL_PTR(substring, "insert_kmer_with_partition()\n")
 
             memcpy(substring, kmer->kmer_comp, nb_bytes_kmer * sizeof(uint8_t));
@@ -5834,10 +5834,10 @@ void write_partition(char* filename, uint8_t* partition_no_iupac, Pvoid_t* parti
 
     uint32_t size_seed_present = CEIL((uint32_t) pow(4, size_seed), SIZE_BITS_UINT_8T);
 
-    uint8_t* seed_comp = malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
+    uint8_t* seed_comp = (uint8_t*) malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_comp, "write_partition()\n")
 
-    uint8_t* seed_ascii = malloc((size_seed + 1) * sizeof(uint8_t));
+    uint8_t* seed_ascii = (uint8_t*) malloc((size_seed + 1) * sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_ascii, "write_partition()\n")
 
     FILE* file_part = fopen(filename, "wb");
@@ -5881,10 +5881,10 @@ void read_partition(char* filename, uint8_t* partition_no_iupac, Pvoid_t* partit
 
     uint32_t size_seed_present = CEIL((uint32_t) pow(4, size_seed), SIZE_BITS_UINT_8T);
 
-    uint8_t* seed_comp = malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
+    uint8_t* seed_comp = (uint8_t*) malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_comp, "write_partition()\n")
 
-    uint8_t* seed_ascii = malloc((size_seed + 1) * sizeof(uint8_t));
+    uint8_t* seed_ascii = (uint8_t*) malloc((size_seed + 1) * sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_ascii, "write_partition()\n")
 
     FILE* file_part = fopen(filename, "rb");
@@ -5955,7 +5955,7 @@ uint8_t find_kmer(BFT* graph_iupac, BFT* graph_no_iupac,
         }
         else{
 
-            seed_comp = calloc(nb_bytes_seed,sizeof(char));
+            seed_comp = (char*) calloc(nb_bytes_seed,sizeof(char));
             ASSERT_NULL_PTR(seed_comp, "decompress() 1")
 
             parseKmerCount(*seed, length_seed, seed_comp, 0);
@@ -5993,7 +5993,7 @@ uint8_t find_kmer(BFT* graph_iupac, BFT* graph_no_iupac,
             }
             else{
 
-                seed_comp = calloc(nb_bytes_seed,sizeof(char));
+                seed_comp = (char*) calloc(nb_bytes_seed,sizeof(char));
                 ASSERT_NULL_PTR(seed_comp, "decompress() 1")
 
                 parseKmerCount(&((*seed)[graph_no_iupac->k - length_seed]), length_seed, seed_comp, 0);
@@ -6059,7 +6059,7 @@ uint8_t find_kmer_custom(BFT* graph_iupac, BFT* graph_no_iupac,
         }
         else{
 
-            seed_comp = calloc(nb_bytes_seed,sizeof(char));
+            seed_comp = (char*) calloc(nb_bytes_seed,sizeof(char));
             ASSERT_NULL_PTR(seed_comp, "decompress() 1")
 
             parseKmerCount(*seed, length_seed, seed_comp, 0);
@@ -6096,7 +6096,7 @@ uint8_t find_kmer_custom(BFT* graph_iupac, BFT* graph_no_iupac,
             }
             else{
 
-                seed_comp = calloc(nb_bytes_seed,sizeof(char));
+                seed_comp = (char*) calloc(nb_bytes_seed,sizeof(char));
                 ASSERT_NULL_PTR(seed_comp, "decompress() 1")
 
                 parseKmerCount(&((*seed)[graph_no_iupac->k - length_seed]), length_seed, seed_comp, 0);
@@ -6145,7 +6145,7 @@ void insert_overlap(char* overlap, int length_overlap, uint8_t* partition_no_iup
     if (is_substring_IUPAC(overlap)) JSLI(PValue_partition_iupac, *partition_iupac, (uint8_t*) overlap)
     else{
 
-        overlap_comp = calloc(nb_bytes_overlap, sizeof(uint8_t));
+        overlap_comp = (uint8_t*) calloc(nb_bytes_overlap, sizeof(uint8_t));
         ASSERT_NULL_PTR(overlap_comp, "insert_overlap()\n")
 
         parseKmerCount(overlap, length_overlap, overlap_comp, 0);
@@ -6250,7 +6250,7 @@ void decompress2(char* output_prefix, bool pair_ended, int size_kmer, int size_s
 
     char buff_int[64];
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "decompress() 3")
 
     strcpy(output_prefix_buffer, output_prefix);
@@ -6272,7 +6272,7 @@ void decompress2(char* output_prefix, bool pair_ended, int size_kmer, int size_s
     file_recycl2 = fopen(output_prefix_buffer, "rb");
     ASSERT_NULL_PTR(file_recycl2,"decompress() 5")
 
-    traversed_kmer_tmp = calloc(size_kmer + 1, sizeof(char));
+    traversed_kmer_tmp = (char*) calloc(size_kmer + 1, sizeof(char));
     ASSERT_NULL_PTR(traversed_kmer_tmp, "decompress() 1")
 
     //Extract the subgraph
@@ -6299,22 +6299,22 @@ void decompress2(char* output_prefix, bool pair_ended, int size_kmer, int size_s
     unserialize_subpaths_recycling(file_recycl2, &prefix_part_recycl, size_seed,
                                    1, 0xffffffff, false);
 
-    partition_no_iupac = calloc(size_annot_seeds, sizeof(uint8_t));
+    partition_no_iupac = (uint8_t*) calloc(size_annot_seeds, sizeof(uint8_t));
     ASSERT_NULL_PTR(partition_no_iupac, "compressKmers_from_KmerFiles()")
 
-    buf_read_info = calloc(SIZE_BUFFER, sizeof(uint8_t));
+    buf_read_info = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
     ASSERT_NULL_PTR(buf_read_info, "decompress() 2.2")
 
-    kmer_run = malloc((size_kmer + 1) * sizeof(char));
+    kmer_run = (char*) malloc((size_kmer + 1) * sizeof(char));
     ASSERT_NULL_PTR(kmer_run, "decompress() 1")
 
-    traversed_kmer = calloc(size_kmer + 1, sizeof(char));
+    traversed_kmer = (char*) calloc(size_kmer + 1, sizeof(char));
     ASSERT_NULL_PTR(traversed_kmer, "decompress() 1")
 
-    suffix = malloc((size_seed + 1) * sizeof(char));
+    suffix = (char*) malloc((size_seed + 1) * sizeof(char));
     ASSERT_NULL_PTR(suffix, "decompress() 3")
 
-    loaded_part = malloc((DECOMP_NB_MAX_LOAD_PART + 1) * sizeof(uint32_t));
+    loaded_part = (uint32_t*) malloc((DECOMP_NB_MAX_LOAD_PART + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(loaded_part, "decompress() 2")
 
     loaded_part[0] = DECOMP_NB_MAX_LOAD_PART;
@@ -6389,10 +6389,10 @@ void decompress2(char* output_prefix, bool pair_ended, int size_kmer, int size_s
 
     //printf("read_length = %" PRIu32 "\n", read_length);
 
-    read = malloc((size_read_buffer + 2) * sizeof(char));
+    read = (char*) malloc((size_read_buffer + 2) * sizeof(char));
     ASSERT_NULL_PTR(read, "decompress() 3")
 
-    read_rc = malloc((size_read_buffer + 2) * sizeof(char));
+    read_rc = (char*) malloc((size_read_buffer + 2) * sizeof(char));
     ASSERT_NULL_PTR(read_rc, "decompress() 3")
 
     header_shift = get_header_next_subseq_shifted(file_shifts);
@@ -6597,10 +6597,10 @@ void decompress2(char* output_prefix, bool pair_ended, int size_kmer, int size_s
 
                         if (read_length > size_read_buffer){
 
-                            read = realloc(read, (read_length + 2) * sizeof(char));
+                            read = (char*) realloc(read, (read_length + 2) * sizeof(char));
                             ASSERT_NULL_PTR(read, "decompress() 3")
 
-                            read_rc = realloc(read_rc, (read_length + 2) * sizeof(char));
+                            read_rc = (char*) realloc(read_rc, (read_length + 2) * sizeof(char));
                             ASSERT_NULL_PTR(read_rc, "decompress() 3")
 
                             size_read_buffer = read_length;
@@ -6843,7 +6843,7 @@ uint32_t unserialize_subpaths_recycling(FILE* file_part_recycl2, Pvoid_t* recycl
 
     uint8_t tmp;
 
-    uint8_t* seed_ascii = malloc((size_seed + 1) * sizeof(uint8_t));
+    uint8_t* seed_ascii = (uint8_t*) malloc((size_seed + 1) * sizeof(uint8_t));
     ASSERT_NULL_PTR(seed_ascii, "serialize_subpaths_recycling()\n")
 
     uint8_t* seed_present;
@@ -6871,7 +6871,7 @@ uint32_t unserialize_subpaths_recycling(FILE* file_part_recycl2, Pvoid_t* recycl
 
                 recycled_part_size_to_load = MIN(nb_parts_to_load, MAX(0, ((int64_t) recycled_part_size) - load_from_pos_start + 1));
 
-                recycled_part = realloc(recycled_part, (recycled_part[0] + recycled_part_size_to_load + 1) * sizeof(uint32_t));
+                recycled_part = (uint32_t*) realloc(recycled_part, (recycled_part[0] + recycled_part_size_to_load + 1) * sizeof(uint32_t));
                 ASSERT_NULL_PTR(recycled_part, "serialize_subpaths_recycling()\n")
 
                 fseek(file_part_recycl2, MIN(load_from_pos_start-1, recycled_part_size) * sizeof(uint32_t), SEEK_CUR);
@@ -6907,7 +6907,7 @@ uint32_t unserialize_subpaths_recycling(FILE* file_part_recycl2, Pvoid_t* recycl
 
                 recycled_part_size_to_load = MIN(nb_parts_to_load, MAX(0, ((int64_t) recycled_part_size) - load_from_pos_start + 1));
 
-                recycled_part = realloc(recycled_part, (recycled_part[0] + recycled_part_size_to_load + 1) * sizeof(uint32_t));
+                recycled_part = (uint32_t*) realloc(recycled_part, (recycled_part[0] + recycled_part_size_to_load + 1) * sizeof(uint32_t));
                 ASSERT_NULL_PTR(recycled_part, "serialize_subpaths_recycling()\n")
 
                 fseek(file_part_recycl2, MIN(load_from_pos_start-1, recycled_part_size) * sizeof(uint32_t), SEEK_CUR);
@@ -6928,10 +6928,10 @@ uint32_t unserialize_subpaths_recycling(FILE* file_part_recycl2, Pvoid_t* recycl
     }
     else{
 
-        seed_present = calloc(size_seed_present, sizeof(uint8_t));
+        seed_present = (uint8_t*) calloc(size_seed_present, sizeof(uint8_t));
         ASSERT_NULL_PTR(seed_present, "serialize_subpaths_recycling()\n")
 
-        seed_comp = malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
+        seed_comp = (uint8_t*) malloc(nb_bytes_seed_iupac * sizeof(uint8_t));
         ASSERT_NULL_PTR(seed_comp, "serialize_subpaths_recycling()\n")
 
         if (size_seed % 4) seed_shift = SIZE_BITS_UINT_8T - ((size_seed % 4) * 2);
@@ -6968,7 +6968,7 @@ uint32_t unserialize_subpaths_recycling(FILE* file_part_recycl2, Pvoid_t* recycl
 
                         recycled_part_size_to_load = MIN(nb_parts_to_load, MAX(0, ((int64_t) recycled_part_size) - load_from_pos_start + 1));
 
-                        recycled_part = malloc((recycled_part_size_to_load + 1) * sizeof(uint32_t));
+                        recycled_part = (uint32_t*) malloc((recycled_part_size_to_load + 1) * sizeof(uint32_t));
                         ASSERT_NULL_PTR(recycled_part, "unserialize_subpaths_recycling()")
 
                         fseek(file_part_recycl2, MIN(load_from_pos_start-1, recycled_part_size) * sizeof(uint32_t), SEEK_CUR);
@@ -7012,7 +7012,7 @@ uint32_t unserialize_subpaths_recycling(FILE* file_part_recycl2, Pvoid_t* recycl
 
             recycled_part_size_to_load = MIN(nb_parts_to_load, MAX(0, ((int64_t) recycled_part_size) - load_from_pos_start + 1));
 
-            recycled_part = malloc((recycled_part_size_to_load + 1) * sizeof(uint32_t));
+            recycled_part = (uint32_t*) malloc((recycled_part_size_to_load + 1) * sizeof(uint32_t));
             ASSERT_NULL_PTR(recycled_part, "unserialize_subpaths_recycling()")
 
             fseek(file_part_recycl2, MIN(load_from_pos_start-1, recycled_part_size) * sizeof(uint32_t), SEEK_CUR);
@@ -7047,12 +7047,12 @@ void sort_subpaths_recycling(Pvoid_t* recycled_parts, int size_seed, bool replac
     uint32_t it_recycled_part;
     uint32_t it_recycled_part_uniq;
 
-    uint32_t* recycled_part_sorted = calloc(1, sizeof(uint32_t));
+    uint32_t* recycled_part_sorted = (uint32_t*) calloc(1, sizeof(uint32_t));
     ASSERT_NULL_PTR(recycled_part_sorted, "decompress()")
 
     uint32_t* recycled_part_not_sorted;
 
-    uint8_t* seed = calloc(size_seed + 1, sizeof(uint8_t));
+    uint8_t* seed = (uint8_t*) calloc(size_seed + 1, sizeof(uint8_t));
     ASSERT_NULL_PTR(seed, "decompress()")
 
     seed[0] = '\0';
@@ -7069,7 +7069,7 @@ void sort_subpaths_recycling(Pvoid_t* recycled_parts, int size_seed, bool replac
 
                 size_recycled_part_sorted = recycled_part_not_sorted[0]+1;
 
-                recycled_part_sorted = realloc(recycled_part_sorted, size_recycled_part_sorted * sizeof(uint32_t));
+                recycled_part_sorted = (uint32_t*) realloc(recycled_part_sorted, size_recycled_part_sorted * sizeof(uint32_t));
                 ASSERT_NULL_PTR(recycled_part_sorted, "decompress()");
             }
 
@@ -7096,14 +7096,14 @@ void sort_subpaths_recycling(Pvoid_t* recycled_parts, int size_seed, bool replac
 
             if (replace_by_sorted_parts){
 
-                recycled_part_not_sorted = realloc(recycled_part_not_sorted, (recycled_part_sorted[0] + 1) * sizeof(uint32_t));
+                recycled_part_not_sorted = (uint32_t*) realloc(recycled_part_not_sorted, (recycled_part_sorted[0] + 1) * sizeof(uint32_t));
                 ASSERT_NULL_PTR(recycled_part_not_sorted, "unserialize_subpaths_recycling()")
 
                 memcpy(recycled_part_not_sorted, recycled_part_sorted, (recycled_part_sorted[0] + 1) * sizeof(uint32_t));
             }
             else{
 
-                recycled_part_not_sorted = realloc(recycled_part_not_sorted,
+                recycled_part_not_sorted = (uint32_t*) realloc(recycled_part_not_sorted,
                                                    (recycled_part_not_sorted[0] + recycled_part_sorted[0] + 2) * sizeof(uint32_t));
 
                 ASSERT_NULL_PTR(recycled_part_not_sorted, "unserialize_subpaths_recycling()")
@@ -7159,7 +7159,7 @@ char* extract_next_subseq_shifted(FILE* file_shift, bool compress_shift, bool is
 
     char* kmer = NULL;
 
-    kmer = calloc(length + 1, sizeof(char));
+    kmer = (char*) calloc(length + 1, sizeof(char));
     ASSERT_NULL_PTR(kmer, "extract_next_subseq_shifted()\n")
 
     int info;
@@ -7168,7 +7168,7 @@ char* extract_next_subseq_shifted(FILE* file_shift, bool compress_shift, bool is
 
         info = CEIL(length * 4, SIZE_BITS_UINT_8T);
 
-        uint8_t* kmer_comp = calloc(info, sizeof(uint8_t));
+        uint8_t* kmer_comp = (uint8_t*) calloc(info, sizeof(uint8_t));
         ASSERT_NULL_PTR(kmer_comp, "extract_next_subseq_shifted()\n")
 
         if (is_iupac){ //IUPAC
@@ -7263,25 +7263,25 @@ void extract_reads(char* output_prefix, bool paired_end){
 
     List* l = List_create();
 
-    Mismatch* mis = malloc(size_mis * sizeof(Mismatch));
+    Mismatch* mis = (Mismatch*) malloc(size_mis * sizeof(Mismatch));
     ASSERT_NULL_PTR(mis, "binning_reads()\n")
 
-    char* buffer_read = malloc(size_buffer_read * sizeof(char));
+    char* buffer_read = (char*) malloc(size_buffer_read * sizeof(char));
     ASSERT_NULL_PTR(buffer_read, "binning_reads()\n")
 
-    char* buffer_rev = malloc(SIZE_BUFFER * sizeof(char));
+    char* buffer_rev = (char*) malloc(SIZE_BUFFER * sizeof(char));
     ASSERT_NULL_PTR(buffer_rev, "binning_reads()\n")
 
-    char* read = malloc(size_read * sizeof(char));
+    char* read = (char*) malloc(size_read * sizeof(char));
     ASSERT_NULL_PTR(read, "binning_reads()\n")
 
-    char* read_tmp = malloc(size_read * sizeof(char));
+    char* read_tmp = (char*) malloc(size_read * sizeof(char));
     ASSERT_NULL_PTR(read_tmp, "binning_reads()\n")
 
-    char* read_rev = malloc(size_read * sizeof(char));
+    char* read_rev = (char*) malloc(size_read * sizeof(char));
     ASSERT_NULL_PTR(read_rev, "binning_reads()\n")
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "extract_reads()\n")
 
     strcpy(output_prefix_buffer, output_prefix);
@@ -7368,19 +7368,19 @@ void extract_reads(char* output_prefix, bool paired_end){
 
                     size_read = read_length + 1;
 
-                    read = realloc(read, size_read * sizeof(char));
+                    read = (char*) realloc(read, size_read * sizeof(char));
                     ASSERT_NULL_PTR(read, "extract_reads()\n")
 
-                    read_tmp = realloc(read_tmp, size_read * sizeof(char));
+                    read_tmp = (char*) realloc(read_tmp, size_read * sizeof(char));
                     ASSERT_NULL_PTR(read_tmp, "extract_reads()\n")
 
-                    read_rev = realloc(read_rev, size_read * sizeof(char));
+                    read_rev = (char*) realloc(read_rev, size_read * sizeof(char));
                     ASSERT_NULL_PTR(read_rev, "extract_reads()\n")
                 }
 
                 if (nb_mismatches){
 
-                    mis = malloc(nb_mismatches * sizeof(Mismatch));
+                    mis = (Mismatch*) malloc(nb_mismatches * sizeof(Mismatch));
                     ASSERT_NULL_PTR(mis, "extract_reads()\n")
 
                     for (i = 0; i < nb_mismatches; i++){
@@ -7503,13 +7503,13 @@ void reorder_paired_reads(char* output_prefix){
 
     size_t size_buffer_read = SIZE_BUFFER;
 
-    char* buffer_read = malloc(size_buffer_read * sizeof(char));
+    char* buffer_read = (char*) malloc(size_buffer_read * sizeof(char));
     ASSERT_NULL_PTR(buffer_read, "reorder_paired_reads() 1\n")
 
-    char* output_prefix_buffer = malloc((len_output_prefix + 50) * sizeof(char));
+    char* output_prefix_buffer = (char*) malloc((len_output_prefix + 50) * sizeof(char));
     ASSERT_NULL_PTR(output_prefix_buffer, "reorder_paired_reads() 2\n")
 
-    uint8_t* buffer_mate_info = malloc(SIZE_BUFFER * sizeof(uint8_t));
+    uint8_t* buffer_mate_info = (uint8_t*) malloc(SIZE_BUFFER * sizeof(uint8_t));
     ASSERT_NULL_PTR(buffer_mate_info, "reorder_paired_reads() 3\n")
 
     strcpy(output_prefix_buffer, output_prefix);

--- a/src/extract_kmers.c
+++ b/src/extract_kmers.c
@@ -36,7 +36,7 @@ size_t iterate_over_kmers_from_node(Node* n, BFT_Root* root, int lvl_node, uint8
 
     uint8_t kmer_tmp[size_kmer_array];
 
-    resultPresence* res_cpy = malloc(sizeof(resultPresence));
+    resultPresence* res_cpy = (resultPresence*) malloc(sizeof(resultPresence));
     ASSERT_NULL_PTR(res_cpy, "l_iterate_over_kmers_from_node()\n");
 
     memcpy(res_cpy, bft_kmer->res, sizeof(resultPresence));
@@ -636,7 +636,7 @@ size_t iterate_over_prefixes_from_node(Node* n, BFT_Root* root, int lvl_node, ui
 
     uint8_t kmer_tmp[size_kmer_array];
 
-    resultPresence* res_cpy = malloc(sizeof(resultPresence));
+    resultPresence* res_cpy = (resultPresence*) malloc(sizeof(resultPresence));
     ASSERT_NULL_PTR(res_cpy, "l_iterate_over_kmers_from_node()\n");
 
     memcpy(res_cpy, bft_kmer->res, sizeof(resultPresence));

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -15,7 +15,7 @@ void compress_annotations_disk(BFT_Root* bft, char* filename_bft){
     int len_longest_annot;
     int lvl_bft = (bft->k / NB_CHAR_SUF_PREF) - 1;
 
-    char* filename_bft_tmp = malloc((strlen(filename_bft) + 50) * sizeof(char));
+    char* filename_bft_tmp = (char*) malloc((strlen(filename_bft) + 50) * sizeof(char));
     ASSERT_NULL_PTR(filename_bft_tmp, "compress_annotations_disk()\n")
 
     strcpy(filename_bft_tmp, filename_bft);
@@ -50,7 +50,7 @@ void compress_annotations_disk(BFT_Root* bft, char* filename_bft){
     #if defined (_WORDx86)
         Word_t * PValue;
 
-        uint8_t* it_index = calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T - 1) + 4), sizeof(uint8_t));
+        uint8_t* it_index = (uint8_t*) calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T - 1) + 4), sizeof(uint8_t));
         ASSERT_NULL_PTR(it_index, "compressKmers_from_KmerFiles()\n");
 
         JSLF(PValue, comp_annots, it_index);
@@ -97,10 +97,10 @@ void insert_Genomes_from_KmerFiles(BFT_Root* root, int nb_files, char** filename
 
     FILE* file;
 
-    uint8_t* array_kmers = calloc(SIZE_BUFFER, sizeof(uint8_t));
+    uint8_t* array_kmers = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
     ASSERT_NULL_PTR(array_kmers,"insert_Genomes_from_KmerFiles()")
 
-    char* line = calloc(100, sizeof(char));
+    char* line = (char*) calloc(100, sizeof(char));
     ASSERT_NULL_PTR(line,"insert_Genomes_from_KmerFiles()")
 
     char* str_tmp;
@@ -245,10 +245,10 @@ void insert_Genomes_from_FASTxFiles(BFT_Root* root, int nb_files, char** filenam
 
     char* str_tmp;
 
-    char* buf_tmp = calloc((size_kmer-1)*2, sizeof(char)); //Allocate temporary buffer
+    char* buf_tmp = (char*) calloc((size_kmer-1)*2, sizeof(char)); //Allocate temporary buffer
     ASSERT_NULL_PTR(buf_tmp,"insert_Genomes_from_FASTxFiles()")
 
-    uint8_t* tab_kmers = calloc(SIZE_BUFFER*nb_cell_kmer, sizeof(uint8_t)); //Allocate buffer for kmers
+    uint8_t* tab_kmers = (uint8_t*) calloc(SIZE_BUFFER*nb_cell_kmer, sizeof(uint8_t)); //Allocate buffer for kmers
     ASSERT_NULL_PTR(tab_kmers,"insert_Genomes_from_FASTxFiles()")
 
     uint64_t kmers_read = 0;
@@ -355,7 +355,7 @@ void insert_Genomes_from_FASTxFiles(BFT_Root* root, int nb_files, char** filenam
                 #if defined (_WORDx86)
                     Word_t * PValue;
 
-                    uint8_t* it_index = calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T) + 4), sizeof(uint8_t));
+                    uint8_t* it_index = (uint8_t*) calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T) + 4), sizeof(uint8_t));
                     ASSERT_NULL_PTR(it_index, "sort_annotations()");
 
                     JSLF(PValue, PJArray, it_index);
@@ -435,13 +435,13 @@ void insert_Genomes_from_FASTxFiles(BFT_Root* root, int nb_files, char** filenam
     uint8_t* annot_ext;
     uint8_t* annot_cplx;
 
-    uint8_t* annot_res = calloc(CEIL(root->nb_genomes+2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    uint8_t* annot_res = (uint8_t*) calloc(CEIL(root->nb_genomes+2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(annot_res,"queryBFT_kmerPresences_from_KmerFiles()")
 
-    uint8_t* array_kmers = calloc(SIZE_BUFFER, sizeof(uint8_t));
+    uint8_t* array_kmers = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
     ASSERT_NULL_PTR(array_kmers,"queryBFT_kmerPresences_from_KmerFiles()")
 
-    char* line = calloc(100, sizeof(char));
+    char* line = (char*) calloc(100, sizeof(char));
     ASSERT_NULL_PTR(line,"queryBFT_kmerPresences_from_KmerFiles()")
 
     file_query = fopen(query_filename, "r");
@@ -684,13 +684,13 @@ int queryBFT_kmerPresences_from_KmerFiles(BFT_Root* root, char* query_filename, 
 
     bool* is_iupac;
 
-    char* buffer_queries = calloc(size_buffer_queries, sizeof(char));
+    char* buffer_queries = (char*) calloc(size_buffer_queries, sizeof(char));
     ASSERT_NULL_PTR(buffer_queries,"query_sequences_outputCSV()\n");
 
-    char* csv_line_res = calloc(root->nb_genomes * 2, sizeof(char));
+    char* csv_line_res = (char*) calloc(root->nb_genomes * 2, sizeof(char));
     ASSERT_NULL_PTR(csv_line_res,"query_sequences_outputCSV()\n");
 
-    uint8_t* array_kmers = calloc(SIZE_BUFFER, sizeof(uint8_t));
+    uint8_t* array_kmers = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
     ASSERT_NULL_PTR(array_kmers,"queryBFT_kmerPresences_from_KmerFiles()")
 
     FILE* file_query = fopen(query_filename, "r");
@@ -774,7 +774,7 @@ int queryBFT_kmerPresences_from_KmerFiles(BFT_Root* root, char* query_filename, 
     }
     else{
 
-        is_iupac = malloc(nb_kmer_in_buf * sizeof(bool));
+        is_iupac = (bool*) malloc(nb_kmer_in_buf * sizeof(bool));
         ASSERT_NULL_PTR(is_iupac, "queryBFT_kmerPresences_from_KmerFiles()")
 
         res_get_line = getline(&buffer_queries, &size_buffer_queries, file_query);
@@ -916,10 +916,10 @@ int queryBFT_kmerBranching_from_KmerFiles(BFT_Root* root, char* query_filename, 
 
     size_t return_fread;
 
-    uint8_t* array_kmers = calloc(SIZE_BUFFER, sizeof(uint8_t));
+    uint8_t* array_kmers = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
     ASSERT_NULL_PTR(array_kmers,"queryBFT_kmerBranching_from_KmerFiles()")
 
-    char* line = calloc(100, sizeof(char));
+    char* line = (char*) calloc(100, sizeof(char));
     ASSERT_NULL_PTR(line,"queryBFT_kmerBranching_from_KmerFiles()")
 
     root->skip_sp = build_skip_nodes(&(root->node));
@@ -1092,48 +1092,48 @@ int queryBFT_kmerBranching_from_KmerFiles(BFT_Root* root, char* query_filename, 
 
             len_output_filename = strlen(prefix_output);
 
-            nb_bfts_on_disk = calloc(nb_threads, sizeof(int));
+            nb_bfts_on_disk = (int*) calloc(nb_threads, sizeof(int));
             ASSERT_NULL_PTR(nb_bfts_on_disk, "par_insert_Genomes_from_KmerFiles()\n")
 
-            output_filename = malloc(nb_threads * sizeof(char*));
+            output_filename = (char**) malloc(nb_threads * sizeof(char*));
             ASSERT_NULL_PTR(output_filename, "par_insert_Genomes_from_KmerFiles()\n")
 
-            output_filename2 = malloc(nb_threads * sizeof(char*));
+            output_filename2 = (char**) malloc(nb_threads * sizeof(char*));
             ASSERT_NULL_PTR(output_filename2, "par_insert_Genomes_from_KmerFiles()\n")
 
-            output_filename3 = malloc((len_output_filename + 30) * sizeof(char));
+            output_filename3 = (char*) malloc((len_output_filename + 30) * sizeof(char));
             ASSERT_NULL_PTR(output_filename3, "merging_BFT()\n");
 
             strcpy(output_filename3, prefix_output);
             strcpy(&output_filename3[strlen(output_filename3)], "_tmp");
 
-            line = malloc(nb_threads * sizeof(char*));
+            line = (char**) malloc(nb_threads * sizeof(char*));
             ASSERT_NULL_PTR(line, "par_insert_Genomes_from_KmerFiles()\n")
 
-            array_kmers = malloc(nb_threads * sizeof(uint8_t*));
+            array_kmers = (uint8_t**) malloc(nb_threads * sizeof(uint8_t*));
             ASSERT_NULL_PTR(array_kmers, "par_insert_Genomes_from_KmerFiles()\n")
 
-            file = malloc(nb_threads * sizeof(FILE*));
+            file = (FILE**) malloc(nb_threads * sizeof(FILE*));
             ASSERT_NULL_PTR(file, "par_insert_Genomes_from_KmerFiles()\n")
 
-            PJArray = malloc(nb_threads * sizeof(PWord_t));
+            PJArray = (PWord_t*) malloc(nb_threads * sizeof(PWord_t));
             ASSERT_NULL_PTR(PJArray, "par_insert_Genomes_from_KmerFiles()\n")
 
-            root = malloc(nb_threads * sizeof(BFT_Root*));
+            root = (BFT_Root**) malloc(nb_threads * sizeof(BFT_Root*));
             ASSERT_NULL_PTR(root, "par_insert_Genomes_from_KmerFiles()\n")
 
             for (it_thread = 0; it_thread < nb_threads; it_thread++){
 
-                line[it_thread] = calloc(100, sizeof(char));
+                line[it_thread] = (char*) calloc(100, sizeof(char));
                 ASSERT_NULL_PTR(line[it_thread], "par_insert_Genomes_from_KmerFiles()\n")
 
-                array_kmers[it_thread] = calloc(SIZE_BUFFER, sizeof(uint8_t));
+                array_kmers[it_thread] = (uint8_t*) calloc(SIZE_BUFFER, sizeof(uint8_t));
                 ASSERT_NULL_PTR(array_kmers[it_thread], "par_insert_Genomes_from_KmerFiles()\n")
 
-                output_filename[it_thread] = malloc((len_output_filename + 30) * sizeof(char));
+                output_filename[it_thread] = (char*) malloc((len_output_filename + 30) * sizeof(char));
                 ASSERT_NULL_PTR(output_filename[it_thread], "merging_BFT()\n");
 
-                output_filename2[it_thread] = malloc((len_output_filename + 30) * sizeof(char));
+                output_filename2[it_thread] = (char*) malloc((len_output_filename + 30) * sizeof(char));
                 ASSERT_NULL_PTR(output_filename2[it_thread], "merging_BFT()\n");
 
                 strcpy(output_filename[it_thread], prefix_output);
@@ -1281,7 +1281,7 @@ int queryBFT_kmerBranching_from_KmerFiles(BFT_Root* root, char* query_filename, 
                     #if defined (_WORDx86)
                         Word_t * PValue;
 
-                        uint8_t* it_index = calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T) + 4), sizeof(uint8_t));
+                        uint8_t* it_index = (uint8_t*) calloc((len_longest_annot + CEIL(len_longest_annot, SIZE_BITS_UINT_8T) + 4), sizeof(uint8_t));
                         ASSERT_NULL_PTR(it_index, "sort_annotations()");
 
                         JSLF(PValue, PJArray[thread_id], it_index);
@@ -1487,10 +1487,10 @@ void query_sequences_outputCSV(BFT_Root* root, char* query_filename, char* outpu
 
     uint32_t* ids_present;
 
-    char* buffer_queries = calloc(size_buffer_queries, sizeof(char));
+    char* buffer_queries = (char*) calloc(size_buffer_queries, sizeof(char));
     ASSERT_NULL_PTR(buffer_queries,"query_sequences_outputCSV()\n");
 
-    char* csv_line_res = calloc(root->nb_genomes * 2, sizeof(char));
+    char* csv_line_res = (char*) calloc(root->nb_genomes * 2, sizeof(char));
     ASSERT_NULL_PTR(csv_line_res,"query_sequences_outputCSV()\n");
 
     FILE* file_query = fopen(query_filename, "r");

--- a/src/insertNode.c
+++ b/src/insertNode.c
@@ -207,7 +207,7 @@ void insertKmer_Node(Node*  node, BFT_Root*  root, int lvl_node, uint8_t*  suffi
         }
         else node_nb_elem = 0;
 
-        node->CC_array = realloc(node->CC_array, (node_nb_elem+1)*sizeof(CC));
+        node->CC_array = (CC*) realloc(node->CC_array, (node_nb_elem+1)*sizeof(CC));
         ASSERT_NULL_PTR(node->CC_array,"insertKmer_Node()")
 
         CC* cc = &(((CC*)node->CC_array)[node_nb_elem]);
@@ -299,8 +299,8 @@ Node* insertKmer_Node_special(BFT_Root*  root, int lvl_cont, uint8_t*  suffix, i
             else count_Node_after_posFilter3 = cc->nb_Node_children - count_nodes(cc, 0, pres->posFilter3+1, type);
 
             //Allocate memory for a new node in CC->children_Node_container
-            if (cc->nb_Node_children == 0) cc->children_Node_container = malloc(sizeof(Node));
-            else cc->children_Node_container = realloc(cc->children_Node_container, (cc->nb_Node_children+1)*sizeof(Node));
+            if (cc->nb_Node_children == 0) cc->children_Node_container = (Node*) malloc(sizeof(Node));
+            else cc->children_Node_container = (Node*) realloc(cc->children_Node_container, (cc->nb_Node_children+1)*sizeof(Node));
 
             ASSERT_NULL_PTR(cc->children_Node_container,"insertKmer_Node_special()")
 
@@ -376,7 +376,7 @@ Node* insertKmer_Node_special(BFT_Root*  root, int lvl_cont, uint8_t*  suffix, i
                 z = uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                     + uc->nb_cplx_nodes * (uc->size_annot_cplx_nodes + SIZE_BYTE_CPLX_N);
 
-                uc->suffixes = realloc(uc->suffixes, ((uc->nb_children+1) * size_line + z) * sizeof(uint8_t));
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((uc->nb_children+1) * size_line + z) * sizeof(uint8_t));
                 ASSERT_NULL_PTR(uc->suffixes, "insertKmer_Node_special()")
 
                 memmove(&(uc->suffixes[pos_sub_size_line+size_line]),

--- a/src/intersection.c
+++ b/src/intersection.c
@@ -54,7 +54,7 @@ uint32_t* intersection_uint32(uint32_t* list_a, uint32_t* list_b){
     uint32_t i = 1, j = 1, it = 0;
     uint32_t size_a = list_a[0]+1, size_b = list_b[0]+1;
 
-    uint32_t* list_c = malloc(MIN(size_a, size_b) * sizeof(uint32_t));
+    uint32_t* list_c = (uint32_t*) malloc(MIN(size_a, size_b) * sizeof(uint32_t));
     ASSERT_NULL_PTR(list_c, "union_lists_uint32() 1\n")
 
     while (i < size_a && j < size_b){
@@ -91,7 +91,7 @@ int comp_uint64(const void *a, const void *b)  {
  */
 uint32_t* intersection_uint32_SIMD(uint32_t* list_a, uint32_t* list_b) {
 
-    uint32_t* list_c = calloc(CEIL(MIN(list_a[0], list_b[0]) + 1, 4) * 4, sizeof(uint32_t));
+    uint32_t* list_c = (uint32_t*) calloc(CEIL(MIN(list_a[0], list_b[0]) + 1, 4) * 4, sizeof(uint32_t));
     ASSERT_NULL_PTR(list_c, "intersection_uint32_SIMD()");
 
     uint32_t* A = &(list_a[1]);
@@ -155,7 +155,7 @@ uint32_t* intersection_uint32_SIMD(uint32_t* list_a, uint32_t* list_b) {
 
     list_c[0] = count;
 
-    list_c = realloc(list_c, (count + 1) * sizeof(uint32_t));
+    list_c = (uint32_t*) realloc(list_c, (count + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(list_c, "intersection_uint32_SIMD()");
 
     return list_c;
@@ -297,7 +297,7 @@ uint64_t* union_lists_uint64(uint64_t* list_a, uint64_t* list_b){
 
     uint64_t size_a = list_a[0]+1, size_b = list_b[0]+1;
 
-    uint64_t* list_c = malloc((size_a + size_b) * sizeof(uint64_t));
+    uint64_t* list_c = (uint64_t*) malloc((size_a + size_b) * sizeof(uint64_t));
     ASSERT_NULL_PTR(list_c, "union_lists_uint64() 1\n")
 
     list_c[0] = 0;
@@ -332,7 +332,7 @@ uint64_t* union_lists_uint64(uint64_t* list_a, uint64_t* list_b){
         j++;
     }
 
-    list_c = realloc(list_c, (list_c[0] + 1) * sizeof(uint64_t));
+    list_c = (uint64_t*) realloc(list_c, (list_c[0] + 1) * sizeof(uint64_t));
     ASSERT_NULL_PTR(list_c, "union_lists_uint64() 2\n")
 
     return list_c;
@@ -346,7 +346,7 @@ uint32_t* union_lists_uint32(uint32_t* list_a, uint32_t* list_b){
     uint32_t i = 1, j = 1, it = 0;
     uint32_t size_a = list_a[0], size_b = list_b[0];
 
-    uint32_t* list_c = malloc((size_a + size_b + 1) * sizeof(uint32_t));
+    uint32_t* list_c = (uint32_t*) malloc((size_a + size_b + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(list_c, "union_lists_uint32() 1\n")
 
     while (i <= size_a && j <= size_b){
@@ -381,7 +381,7 @@ uint32_t* union_lists_uint32(uint32_t* list_a, uint32_t* list_b){
 
     list_c[0] = it;
 
-    list_c = realloc(list_c, (list_c[0] + 1) * sizeof(uint32_t));
+    list_c = (uint32_t*) realloc(list_c, (list_c[0] + 1) * sizeof(uint32_t));
     ASSERT_NULL_PTR(list_c, "union_lists_uint32() 2\n")
 
     return list_c;

--- a/src/list.c
+++ b/src/list.c
@@ -35,7 +35,7 @@ void List_clear_destroy(List *list)
 
 void List_push(List *list, void *value)
 {
-    ListNode *node = calloc(1, sizeof(ListNode));
+    ListNode *node = (ListNode*) calloc(1, sizeof(ListNode));
     ASSERT_NULL_PTR(node, "List_push()\n")
 
     node->value = value;
@@ -130,7 +130,7 @@ ListNode* List_insert(List *list, ListNode *node_after_insert, void* value)
     }
     else {
 
-        ListNode *new_node = calloc(1, sizeof(ListNode));
+        ListNode *new_node = (ListNode*) calloc(1, sizeof(ListNode));
         ASSERT_NULL_PTR(new_node, "List_push()\n")
 
         new_node->value = value;

--- a/src/main.c
+++ b/src/main.c
@@ -156,14 +156,14 @@ int main(int argc, char *argv[])
 
             if ((file_input = fopen(argv[4], "r")) == NULL) ERROR("Invalid list_genome_files.\n")
 
-            paths_and_names = malloc(nb_files_2_read * sizeof(char*)); //Allocate the array of paths + filenames
+            paths_and_names = (char**) malloc(nb_files_2_read * sizeof(char*)); //Allocate the array of paths + filenames
             ASSERT_NULL_PTR(paths_and_names,"main()")
 
             i = 0;
 
             while (fgets(buffer, 2048, file_input)){ //Copy the filenames in an array, the paths and filenames in another array
 
-                paths_and_names[i] = malloc((strlen(buffer) + 1) * sizeof(char));
+                paths_and_names[i] = (char*) malloc((strlen(buffer) + 1) * sizeof(char));
                 ASSERT_NULL_PTR(paths_and_names[i], "main()")
 
                 strcpy(paths_and_names[i], buffer);
@@ -218,14 +218,14 @@ int main(int argc, char *argv[])
 
                 if ((file_input = fopen(argv[i+2], "r")) == NULL) ERROR("Invalid list_genome_files.\n")
 
-                paths_and_names = malloc(nb_files_2_read * sizeof(char*)); //Allocate the array of paths + filenames
+                paths_and_names = (char**) malloc(nb_files_2_read * sizeof(char*)); //Allocate the array of paths + filenames
                 ASSERT_NULL_PTR(paths_and_names,"main()")
 
                 j = 0;
 
                 while (fgets(buffer, 2048, file_input)){ //Copy the filenames in an array, the paths and filenames in another array
 
-                    paths_and_names[j] = malloc((strlen(buffer)+1)*sizeof(char));
+                    paths_and_names[j] = (char*) malloc((strlen(buffer)+1)*sizeof(char));
                     ASSERT_NULL_PTR(paths_and_names[j],"main()")
 
                     strcpy(paths_and_names[j], buffer);
@@ -255,7 +255,7 @@ int main(int argc, char *argv[])
 
                     buffer[strcspn(buffer, "\r\n")] = 0;
 
-                    filename_output = malloc((strlen(basename(buffer))+4) * sizeof(char));
+                    filename_output = (char*) malloc((strlen(basename(buffer))+4) * sizeof(char));
                     ASSERT_NULL_PTR(filename_output, "main()")
 
                     strcpy(filename_output, basename(buffer));
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
 
                     buffer[strcspn(buffer, "\r\n")] = '\0';
 
-                    filename_output = malloc((strlen(basename(buffer))+4) * sizeof(char));
+                    filename_output = (char*) malloc((strlen(basename(buffer))+4) * sizeof(char));
                     ASSERT_NULL_PTR(filename_output, "main()")
 
                     strcpy(filename_output, basename(buffer));

--- a/src/marking.c
+++ b/src/marking.c
@@ -53,7 +53,7 @@ void create_marking_CC_4states(CC* cc, int lvl_cc, int size_kmer, info_per_level
                         + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes);
 
             if (tot + sup_bytes > 0){
-                uc->suffixes = realloc(uc->suffixes, (tot + sup_bytes) * sizeof(uint8_t));
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes, (tot + sup_bytes) * sizeof(uint8_t));
                 ASSERT_NULL_PTR(uc->suffixes, "create_marking_CC_4states")
 
                 memset(&(uc->suffixes[tot]), 0, sup_bytes * sizeof(uint8_t));
@@ -75,7 +75,7 @@ void create_marking_CC_4states(CC* cc, int lvl_cc, int size_kmer, info_per_level
             sup_bytes = CEIL(uc->nb_children * 2, SIZE_BITS_UINT_8T);
 
             if (tot + sup_bytes > 0){
-                uc->suffixes = realloc(uc->suffixes, (tot + sup_bytes) * sizeof(uint8_t));
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes, (tot + sup_bytes) * sizeof(uint8_t));
                 ASSERT_NULL_PTR(uc->suffixes, "create_marking_CC_4states")
 
                 memset(&(uc->suffixes[tot]), 0, sup_bytes * sizeof(uint8_t));
@@ -102,7 +102,7 @@ void create_marking_UC_4states(UC* uc, int lvl_uc, info_per_level*  info_per_lvl
     int sup_bytes = CEIL(nb_elt * 2, SIZE_BITS_UINT_8T);
 
     if (tot + sup_bytes > 0){
-        uc->suffixes = realloc(uc->suffixes, (tot + sup_bytes) * sizeof(uint8_t));
+        uc->suffixes = (uint8_t*) realloc(uc->suffixes, (tot + sup_bytes) * sizeof(uint8_t));
         ASSERT_NULL_PTR(uc->suffixes, "create_marking_UC_4states")
 
         memset(&(uc->suffixes[tot]), 0, sup_bytes * sizeof(uint8_t));
@@ -148,13 +148,13 @@ void delete_marking_CC_4states(CC* cc, int lvl_cc, int size_kmer, info_per_level
             uc = &(((UC*)cc->children)[i]);
 
             if (i != nb_skp-1){
-                uc->suffixes = realloc(uc->suffixes, (info_per_lvl[lvl_cc].nb_ucs_skp * uc->size_annot
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes, (info_per_lvl[lvl_cc].nb_ucs_skp * uc->size_annot
                                                       + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                                       + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes))
                                                         * sizeof(uint8_t));
             }
             else{
-                uc->suffixes = realloc(uc->suffixes, ((cc->nb_elem - i * info_per_lvl[lvl_cc].nb_ucs_skp) * uc->size_annot
+                uc->suffixes = (uint8_t*) realloc(uc->suffixes, ((cc->nb_elem - i * info_per_lvl[lvl_cc].nb_ucs_skp) * uc->size_annot
                                                       + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                                       + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes))
                                                         * sizeof(uint8_t));
@@ -171,7 +171,7 @@ void delete_marking_CC_4states(CC* cc, int lvl_cc, int size_kmer, info_per_level
 
             uc = &(((UC*)cc->children)[i]);
 
-            uc->suffixes = realloc(uc->suffixes, (uc->nb_children * (size_substring + uc->size_annot)
+            uc->suffixes = (uint8_t*) realloc(uc->suffixes, (uc->nb_children * (size_substring + uc->size_annot)
                                                   + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                                   + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes))
                                                 * sizeof(uint8_t));
@@ -190,7 +190,7 @@ void delete_marking_UC_4states(UC* uc, int size_substring, int nb_children){
     ASSERT_NULL_PTR(uc, "delete_marking_UC_4states()")
     ASSERT_NULL_PTR(uc->suffixes, "delete_marking_UC_4states()")
 
-    uc->suffixes = realloc(uc->suffixes, (nb_children * (size_substring + uc->size_annot)
+    uc->suffixes = (uint8_t*) realloc(uc->suffixes, (nb_children * (size_substring + uc->size_annot)
                                           + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                           + uc->nb_cplx_nodes * (SIZE_BYTE_CPLX_N + uc->size_annot_cplx_nodes))
                                             * sizeof(uint8_t));

--- a/src/merge.c
+++ b/src/merge.c
@@ -41,10 +41,10 @@
 
     char** new_filename;
 
-    char** output_filename = malloc(sizeof(char*));
+    char** output_filename = (char**) malloc(sizeof(char*));
     ASSERT_NULL_PTR(output_filename, "merging_BFT() 4\n");
 
-    output_filename[0] = malloc((len_output_filename + 30) * sizeof(char));
+    output_filename[0] = (char*) malloc((len_output_filename + 30) * sizeof(char));
     ASSERT_NULL_PTR(output_filename[0], "merging_BFT() 4\n");
 
     strcpy(output_filename[0], output_prefix);
@@ -55,7 +55,7 @@
         while (IS_EVEN(((CC*)bft1->node.CC_array)[nb_ccs_bft1-1].type));
     }
 
-    files_cc = malloc((nb_ccs_bft1 + 1) * sizeof(FILE*));
+    files_cc = (FILE**) malloc((nb_ccs_bft1 + 1) * sizeof(FILE*));
     ASSERT_NULL_PTR(files_cc, "merging_BFT() 6\n");
 
     for (j = 0; j <= nb_ccs_bft1; j++){
@@ -87,41 +87,41 @@
             {
                 nb_threads = omp_get_num_threads();
 
-                bfts_insert = malloc(nb_threads * sizeof(BFT*));
+                bfts_insert = (BFT**) malloc(nb_threads * sizeof(BFT*));
                 ASSERT_NULL_PTR(bfts_insert, "merging_BFT() 3\n");
 
-                new_filename = malloc(nb_threads * sizeof(char*));
+                new_filename = (char**) malloc(nb_threads * sizeof(char*));
                 ASSERT_NULL_PTR(new_filename, "merging_BFT() 3\n");
 
-                output_filename = malloc(nb_threads * sizeof(char*));
+                output_filename = (char**) malloc(nb_threads * sizeof(char*));
                 ASSERT_NULL_PTR(output_filename, "merging_BFT() 3\n");
 
-                kmer_comp = malloc(nb_threads * sizeof(uint8_t*));
+                kmer_comp = (uint8_t**) malloc(nb_threads * sizeof(uint8_t*));
                 ASSERT_NULL_PTR(kmer_comp, "merging_BFT() 3\n");
 
-                kmer_comp_cpy = malloc(nb_threads * sizeof(uint8_t*));
+                kmer_comp_cpy = (uint8_t**) malloc(nb_threads * sizeof(uint8_t*));
                 ASSERT_NULL_PTR(kmer_comp_cpy, "merging_BFT() 3\n");
 
-                bft_annot = malloc(nb_threads * sizeof(BFT_annotation*));
+                bft_annot = (BFT_annotation**) malloc(nb_threads * sizeof(BFT_annotation*));
                 ASSERT_NULL_PTR(bft_annot, "merging_BFT() 3\n");
 
                 for (i = 0; i < nb_threads; i++){
 
                     bfts_insert[i] = copy_BFT_Root(bft1);
 
-                    kmer_comp[i] = malloc(nb_bytes * sizeof(uint8_t));
+                    kmer_comp[i] = (uint8_t*) malloc(nb_bytes * sizeof(uint8_t));
                     ASSERT_NULL_PTR(kmer_comp[i], "merging_BFT() 1\n");
 
-                    kmer_comp_cpy[i] = malloc(nb_bytes * sizeof(uint8_t));
+                    kmer_comp_cpy[i] = (uint8_t*) malloc(nb_bytes * sizeof(uint8_t));
                     ASSERT_NULL_PTR(kmer_comp_cpy[i], "merging_BFT() 1\n");
 
-                    new_filename[i] = malloc((len_filename_cc + 30) * sizeof(char));
+                    new_filename[i] = (char*) malloc((len_filename_cc + 30) * sizeof(char));
                     ASSERT_NULL_PTR(new_filename[i], "merging_BFT() 3\n");
 
                     strcpy(new_filename[i], prefix_bft1);
                     new_filename[i][len_filename_cc] = '_';
 
-                    output_filename[i] = malloc((len_output_filename + 30) * sizeof(char));
+                    output_filename[i] = (char*) malloc((len_output_filename + 30) * sizeof(char));
                     ASSERT_NULL_PTR(output_filename[i], "merging_BFT() 3\n");
 
                     strcpy(output_filename[i], output_prefix);
@@ -129,7 +129,7 @@
 
                     bft_annot[i] = create_BFT_annotation();
 
-                    bft_annot[i]->annot = calloc(SIZE_MAX_BYTE_ANNOT, sizeof(uint8_t));
+                    bft_annot[i]->annot = (uint8_t*) calloc(SIZE_MAX_BYTE_ANNOT, sizeof(uint8_t));
                     ASSERT_NULL_PTR(bft_annot[i]->annot, "merging_BFT() 5\n");
                 }
             }

--- a/src/presenceNode.c
+++ b/src/presenceNode.c
@@ -1227,7 +1227,7 @@ int* get_bf_presence_per_cc(BFT_Root* root){
     int i;
     int size_pres_bf = pow(4, NB_CHAR_SUF_PREF);
 
-    int* presence_bf = malloc(size_pres_bf * sizeof(int));
+    int* presence_bf = (int*) malloc(size_pres_bf * sizeof(int));
     ASSERT_NULL_PTR(presence_bf, "get_bf_presence_per_cc()\n");
 
     info_per_level* info_per_lvl = &(root->info_per_lvl[root->k / NB_CHAR_SUF_PREF - 1]);
@@ -1841,7 +1841,7 @@ resultPresence* isKmerPresent(Node*  node, BFT_Root* root, int lvl_node, uint8_t
     uint8_t kmer_tmp[root->info_per_lvl[lvl_node].size_kmer_in_bytes];
     memcpy(kmer_tmp, kmer, root->info_per_lvl[lvl_node].size_kmer_in_bytes);
 
-    resultPresence* res = malloc(sizeof(resultPresence));
+    resultPresence* res = (resultPresence*) malloc(sizeof(resultPresence));
     ASSERT_NULL_PTR(res,"isKmerPresent()")
 
     //We want to start the search at the beginning of the node so 4th argument is 0
@@ -1937,18 +1937,18 @@ bool prefix_matching_comp(BFT* bft, uint8_t* prefix_comp, int length_prefix, BFT
 
     size_t return_value;
 
-    uint8_t* prefix_comp_cpy = calloc(size_kmer_comp, sizeof(uint8_t));
+    uint8_t* prefix_comp_cpy = (uint8_t*) calloc(size_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(prefix_comp_cpy, "prefix_matching()\n")
 
-    uint8_t* shifted_prefix_comp = calloc(size_kmer_comp, sizeof(uint8_t));
+    uint8_t* shifted_prefix_comp = (uint8_t*) calloc(size_kmer_comp, sizeof(uint8_t));
     ASSERT_NULL_PTR(shifted_prefix_comp, "prefix_matching_comp()\n")
 
     BFT_kmer* bft_kmer = create_empty_kmer();
 
-    bft_kmer->kmer = malloc((bft->k + 1) * sizeof(char));
+    bft_kmer->kmer = (char*) malloc((bft->k + 1) * sizeof(char));
     ASSERT_NULL_PTR(bft_kmer->kmer, "prefix_matching_comp()\n")
 
-    bft_kmer->kmer_comp = calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
+    bft_kmer->kmer_comp = (uint8_t*) calloc(CEIL(bft->k * 2, SIZE_BITS_UINT_8T), sizeof(uint8_t));
     ASSERT_NULL_PTR(bft_kmer->kmer_comp, "prefix_matching_comp()\n")
 
     bft_kmer->res = create_resultPresence();
@@ -2006,13 +2006,13 @@ bool prefix_matching_comp(BFT* bft, uint8_t* prefix_comp, int length_prefix, BFT
     CC* cc;
     UC* uc;
 
-    resultPresence* res = malloc(sizeof(resultPresence));
+    resultPresence* res = (resultPresence*) malloc(sizeof(resultPresence));
     ASSERT_NULL_PTR(res,"prefix_matching()\n")
 
     uint8_t* prefix_comp;
     uint8_t* kmer_comp;
 
-    uint8_t* shifted_prefix_cpy = malloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes * sizeof(uint8_t));
+    uint8_t* shifted_prefix_cpy = (uint8_t*) malloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes * sizeof(uint8_t));
     ASSERT_NULL_PTR(shifted_prefix_cpy, "prefix_matching()\n")
 
     memcpy(shifted_prefix_cpy, shifted_prefix, size_prefix_shifted_bytes * sizeof(uint8_t));
@@ -2118,7 +2118,7 @@ bool prefix_matching_comp(BFT* bft, uint8_t* prefix_comp, int length_prefix, BFT
 
         nb_prefixes_possible = pow(4, NB_CHAR_SUF_PREF - size_prefix_shifted);
 
-        prefix_comp = calloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes, sizeof(uint8_t));
+        prefix_comp = (uint8_t*) calloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes, sizeof(uint8_t));
         ASSERT_NULL_PTR(prefix_comp, "serialize_subpaths_recycling()\n")
 
         if (NB_CHAR_SUF_PREF % 4) prefix_shift = SIZE_BITS_UINT_8T - ((NB_CHAR_SUF_PREF % 4) * 2);
@@ -2145,7 +2145,7 @@ bool prefix_matching_comp(BFT* bft, uint8_t* prefix_comp, int length_prefix, BFT
 
                     if (res->container_is_UC == 0){
 
-                        kmer_comp = calloc(size_kmer_bytes, sizeof(uint8_t));
+                        kmer_comp = (uint8_t*) calloc(size_kmer_bytes, sizeof(uint8_t));
                         ASSERT_NULL_PTR(kmer_comp, "prefix_matching()\n")
 
 
@@ -2278,12 +2278,12 @@ size_t v_prefix_matching(Node* node, BFT_Root* root, int lvl_node,
     CC* cc;
     UC* uc;
 
-    resultPresence* res = malloc(sizeof(resultPresence));
+    resultPresence* res = (resultPresence*) malloc(sizeof(resultPresence));
     ASSERT_NULL_PTR(res,"prefix_matching()\n")
 
     uint8_t* kmer_comp;
 
-    uint8_t* shifted_prefix_cpy = malloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes * sizeof(uint8_t));
+    uint8_t* shifted_prefix_cpy = (uint8_t*) malloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes * sizeof(uint8_t));
     ASSERT_NULL_PTR(shifted_prefix_cpy, "prefix_matching()\n")
 
     memcpy(shifted_prefix_cpy, shifted_prefix, size_prefix_shifted_bytes * sizeof(uint8_t));
@@ -2382,7 +2382,7 @@ size_t v_prefix_matching(Node* node, BFT_Root* root, int lvl_node,
     }
     else{
 
-        kmer_comp = calloc(size_kmer_bytes, sizeof(uint8_t));
+        kmer_comp = (uint8_t*) calloc(size_kmer_bytes, sizeof(uint8_t));
         ASSERT_NULL_PTR(kmer_comp, "prefix_matching()\n")
 
         length_rounded_prefix = root->k - (lvl_node + 1) * NB_CHAR_SUF_PREF;
@@ -2482,10 +2482,10 @@ size_t v_prefix_matching_custom(Node* node, BFT_Root* root, int lvl_node,
     uint8_t* kmer_comp;
     uint8_t* shifted_prefix_cpy;
 
-    resultPresence* res = malloc(sizeof(resultPresence));
+    resultPresence* res = (resultPresence*) malloc(sizeof(resultPresence));
     ASSERT_NULL_PTR(res,"prefix_matching()\n")
 
-    shifted_prefix_cpy = malloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes * sizeof(uint8_t));
+    shifted_prefix_cpy = (uint8_t*) malloc(root->info_per_lvl[lvl_node].size_kmer_in_bytes * sizeof(uint8_t));
     ASSERT_NULL_PTR(shifted_prefix_cpy, "prefix_matching()\n")
 
     memcpy(shifted_prefix_cpy, shifted_prefix, size_prefix_shifted_bytes * sizeof(uint8_t));
@@ -2610,7 +2610,7 @@ size_t v_prefix_matching_custom(Node* node, BFT_Root* root, int lvl_node,
     }
     else{
 
-        kmer_comp = calloc(size_kmer_bytes, sizeof(uint8_t));
+        kmer_comp = (uint8_t*) calloc(size_kmer_bytes, sizeof(uint8_t));
         ASSERT_NULL_PTR(kmer_comp, "prefix_matching()\n")
 
         length_rounded_prefix = root->k - (lvl_node + 1) * NB_CHAR_SUF_PREF;

--- a/src/printMemory.c
+++ b/src/printMemory.c
@@ -10,7 +10,7 @@
 *  ---------------------------------------------------------------------------------------------------------------
 */
 memory_Used* create_memory_Used(){
-    memory_Used* mem = calloc(1,sizeof(memory_Used));
+    memory_Used* mem = (memory_Used*) calloc(1,sizeof(memory_Used));
     ASSERT_NULL_PTR(mem,"create_memory_Used()")
 
     return mem;

--- a/src/quicksort.c
+++ b/src/quicksort.c
@@ -178,7 +178,7 @@ void quicksort_uint64(uint64_t* a, uint64_t* b, uint64_t p, uint64_t r)
 
 int* quicksort_init(uint8_t* substrings, int size_line_sub, int p, int r)
 {
-    int* tab_ind = malloc((r+1)*sizeof(int));
+    int* tab_ind = (int*) malloc((r+1)*sizeof(int));
 
     ASSERT_NULL_PTR(substrings,"quicksort_init()")
     ASSERT_NULL_PTR(tab_ind,"quicksort_init()")

--- a/src/replaceAnnotation.c
+++ b/src/replaceAnnotation.c
@@ -111,7 +111,7 @@ void load_annotation_from_UC(UC* uc, int size_substring, int nb_children, int lo
         uint8_t* annot_tmp;
         uint8_t* annot_start;
 
-        uint8_t* annot = calloc(longest_annot + CEIL(longest_annot, bits_per_byte_checksum) + 4, sizeof(uint8_t));
+        uint8_t* annot = (uint8_t*) calloc(longest_annot + CEIL(longest_annot, bits_per_byte_checksum) + 4, sizeof(uint8_t));
         ASSERT_NULL_PTR(annot, "load_annotation_from_UC()")
 
         uint8_t** extended_annots = get_extend_annots(uc, size_substring, nb_children, 0, nb_children-1);
@@ -190,7 +190,7 @@ void load_annotation_from_UC(UC* uc, int size_substring, int nb_children, int lo
                 else *PValue += size_decomp << 32;
             #else
                 if (*PValue == NULL){
-                    *PValue = malloc(sizeof(uint64_t));
+                    *PValue = (uint64_t*) malloc(sizeof(uint64_t));
                     ASSERT_NULL_PTR(*PValue, "load_annotation_from_UC()")
 
                     **((uint64_t**)PValue) = (size_decomp << 32) | size_decomp;
@@ -247,7 +247,7 @@ int compress_annotation_from_UC(UC* uc, int size_substring, int nb_children,
 
         uint32_t id = 0;
 
-        uint32_t* positions = calloc(nb_children, sizeof(uint32_t));
+        uint32_t* positions = (uint32_t*) calloc(nb_children, sizeof(uint32_t));
         ASSERT_NULL_PTR(positions,"compress_annotation_from_UC() 4")
 
         if (extended_annots != NULL) max_size_annot = uc->size_annot + 1;
@@ -291,7 +291,7 @@ int compress_annotation_from_UC(UC* uc, int size_substring, int nb_children,
 
         size_line_annot = max_size_annot + CEIL(max_size_annot, bits_per_byte_checksum) + 4;
 
-        annotations = calloc(nb_children * size_line_annot, sizeof(uint8_t));
+        annotations = (uint8_t*) calloc(nb_children * size_line_annot, sizeof(uint8_t));
         ASSERT_NULL_PTR(annotations,"compress_annotation_from_UC() 3")
 
         for (z = 0; z < nb_children; z++){
@@ -359,7 +359,7 @@ int compress_annotation_from_UC(UC* uc, int size_substring, int nb_children,
 
         new_size_line = size_substring + size_max;
 
-        new_tab_sub = calloc(nb_children * new_size_line, sizeof(uint8_t));
+        new_tab_sub = (uint8_t*) calloc(nb_children * new_size_line, sizeof(uint8_t));
         ASSERT_NULL_PTR(new_tab_sub,"compress_annotation_from_UC() 2")
 
         for (z = 0; z < nb_children; z++){
@@ -569,7 +569,7 @@ void load_annotation_from_UC(UC* uc, int size_substring, int nb_children, int lo
 
         UC_SIZE_ANNOT_T *min_sizes = min_size_per_sub(uc->suffixes, nb_children, size_substring, uc->size_annot);
 
-        uint8_t* annot = calloc(longest_annot + CEIL(longest_annot, bits_per_byte_checksum) + 4, sizeof(uint8_t));
+        uint8_t* annot = (uint8_t*) calloc(longest_annot + CEIL(longest_annot, bits_per_byte_checksum) + 4, sizeof(uint8_t));
         ASSERT_NULL_PTR(annot, "load_annotation_from_UC()")
 
         for (i=0; i<nb_children; i++){
@@ -651,7 +651,7 @@ void load_annotation_from_UC(UC* uc, int size_substring, int nb_children, int lo
                 else *PValue += size_decomp << 32;
             #else
                 if (*PValue == NULL){
-                    *PValue = malloc(sizeof(uint64_t));
+                    *PValue = (uint64_t*) malloc(sizeof(uint64_t));
                     ASSERT_NULL_PTR(*PValue, "load_annotation_from_UC()")
 
                     **((uint64_t**)PValue) = (size_decomp << 32) | size_decomp;
@@ -781,7 +781,7 @@ int compress_annotation_from_UC(UC* uc, int size_substring, int nb_children, Pvo
         int size_max_annot_cmp = 0;
         int longest_annot = 0;
 
-        uint32_t* positions = calloc(nb_children, sizeof(uint32_t));
+        uint32_t* positions = (uint32_t*) calloc(nb_children, sizeof(uint32_t));
         ASSERT_NULL_PTR(positions,"compress_annotation_from_UC() 4")
 
         if (extended_annots != NULL) max_size_annot = uc->size_annot + 1;
@@ -818,7 +818,7 @@ int compress_annotation_from_UC(UC* uc, int size_substring, int nb_children, Pvo
 
         size_line_annot = max_size_annot + CEIL(max_size_annot, bits_per_byte_checksum) + 4;
 
-        annotations = calloc(nb_children * size_line_annot, sizeof(uint8_t));
+        annotations = (uint8_t*) calloc(nb_children * size_line_annot, sizeof(uint8_t));
         ASSERT_NULL_PTR(annotations,"compress_annotation_from_UC() 3")
 
         for (z=0; z<nb_children; z++){
@@ -905,7 +905,7 @@ int compress_annotation_from_UC(UC* uc, int size_substring, int nb_children, Pvo
         new_size_line = size_substring + size_max;
         uc->size_annot = size_max;
 
-        new_tab_sub = calloc(nb_children * new_size_line, sizeof(uint8_t));
+        new_tab_sub = (uint8_t*) calloc(nb_children * new_size_line, sizeof(uint8_t));
         ASSERT_NULL_PTR(new_tab_sub,"compress_annotation_from_UC() 2")
 
         for (z = 0; z < nb_children; z++){

--- a/src/retrieveAnnotation.c
+++ b/src/retrieveAnnotation.c
@@ -37,7 +37,7 @@
 
             if (annot_present != 0){
 
-                annot_res = malloc(MAX(size_annot+1, size_annot_cplx)*sizeof(uint8_t));
+                annot_res = (uint8_t*) malloc(MAX(size_annot+1, size_annot_cplx)*sizeof(uint8_t));
                 ASSERT_NULL_PTR(annot_res,"retrieve_annotation_right()")
 
                 if (size_annot != 0) memcpy(annot_res, annot, size_annot * sizeof(uint8_t));
@@ -58,7 +58,7 @@
                     continue;
                 }
                 else{
-                    ann_arr_elem = malloc(sizeof(annotation_array_elem));
+                    ann_arr_elem = (annotation_array_elem*) malloc(sizeof(annotation_array_elem));
                     ASSERT_NULL_PTR(ann_arr_elem,"retrieve_annotation_right()")
 
                     ann_arr_elem->annot_array = annot_res;
@@ -70,7 +70,7 @@
                 }
             }
             else{
-                kmer = malloc(size_kmer_array * sizeof(uint8_t));
+                kmer = (uint8_t*) malloc(size_kmer_array * sizeof(uint8_t));
                 ASSERT_NULL_PTR(kmer,"retrieve_annotation_right()")
 
                 memcpy(kmer, kmer_start, size_kmer_array*sizeof(uint8_t));
@@ -130,7 +130,7 @@ annotation_array_elem* retrieve_annotation_left(Node* root, uint8_t* kmer_start,
 
             if (annot_present != 0){
 
-                annot_res = malloc(MAX(size_annot+1, size_annot_cplx)*sizeof(uint8_t));
+                annot_res = (uint8_t*) malloc(MAX(size_annot+1, size_annot_cplx)*sizeof(uint8_t));
                 ASSERT_NULL_PTR(annot_res,"retrieve_annotation_left()")
 
                 if (size_annot != 0) memcpy(annot_res, annot, size_annot * sizeof(uint8_t));
@@ -151,7 +151,7 @@ annotation_array_elem* retrieve_annotation_left(Node* root, uint8_t* kmer_start,
                     continue;
                 }
                 else{
-                    ann_arr_elem = malloc(sizeof(annotation_array_elem));
+                    ann_arr_elem = (annotation_array_elem*) malloc(sizeof(annotation_array_elem));
                     ASSERT_NULL_PTR(ann_arr_elem,"retrieve_annotation_right()")
 
                     ann_arr_elem->annot_array = annot_res;
@@ -163,7 +163,7 @@ annotation_array_elem* retrieve_annotation_left(Node* root, uint8_t* kmer_start,
                 }
             }
             else{
-                kmer = malloc(size_kmer_array * sizeof(uint8_t));
+                kmer = (uint8_t*) malloc(size_kmer_array * sizeof(uint8_t));
                 ASSERT_NULL_PTR(kmer,"retrieve_annotation_left()")
 
                 memcpy(kmer, kmer_start, size_kmer_array*sizeof(uint8_t));
@@ -184,7 +184,7 @@ annotation_array_elem* retrieve_annotation_left(Node* root, uint8_t* kmer_start,
 
     free(res);
 
-    ann_arr_elem = malloc(sizeof(annotation_array_elem));
+    ann_arr_elem = (annotation_array_elem*) malloc(sizeof(annotation_array_elem));
     ASSERT_NULL_PTR(ann_arr_elem,"retrieve_annotation_right()")
 
     ann_arr_elem->annot_array = NULL;

--- a/src/snippets.c
+++ b/src/snippets.c
@@ -149,7 +149,7 @@ size_t extract_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
             //Initiate the ASCII simple path with the extension seed
             l_simple_path = graph->k;
 
-            char* simple_path = malloc(l_simple_path * sizeof(char));
+            char* simple_path = (char*) malloc(l_simple_path * sizeof(char));
             ASSERT_NULL_PTR(simple_path, "extract_simple_paths()\n");
 
             memcpy(simple_path, kmer->kmer, l_simple_path * sizeof(char));
@@ -186,7 +186,7 @@ size_t extract_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
                         l_simple_path++; //Increase length of the current simple path
 
                         //Reallocate the simple path to match new length
-                        simple_path = realloc(simple_path, l_simple_path * sizeof(char));
+                        simple_path = (char*) realloc(simple_path, l_simple_path * sizeof(char));
                         ASSERT_NULL_PTR(simple_path, "extract_simple_paths()\n");
 
                         //Copy last character of the current successor to the end of the simple path
@@ -250,7 +250,7 @@ size_t extract_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
                         l_simple_path++; //Increase length of the current simple path
 
                         //Reallocate the simple path to match new length
-                        simple_path = realloc(simple_path, l_simple_path * sizeof(char));
+                        simple_path = (char*) realloc(simple_path, l_simple_path * sizeof(char));
                         ASSERT_NULL_PTR(simple_path, "extract_simple_paths()\n");
 
                         //Shift the current path of one character on the right
@@ -279,7 +279,7 @@ size_t extract_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
             }
 
             //Prepare the simple path for file writing
-            simple_path = realloc(simple_path, (l_simple_path+1) * sizeof(char));
+            simple_path = (char*) realloc(simple_path, (l_simple_path+1) * sizeof(char));
             ASSERT_NULL_PTR(simple_path, "extract_simple_paths()\n");
 
             simple_path[l_simple_path] = '\n';
@@ -390,7 +390,7 @@ size_t extract_core_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
 
             l_simple_path = graph->k;
 
-            char* simple_path = malloc(l_simple_path * sizeof(char));
+            char* simple_path = (char*) malloc(l_simple_path * sizeof(char));
             ASSERT_NULL_PTR(simple_path, "extract_core_simple_paths()\n");
 
             memcpy(simple_path, kmer->kmer, l_simple_path * sizeof(char));
@@ -435,7 +435,7 @@ size_t extract_core_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
 
                         l_simple_path++;
 
-                        simple_path = realloc(simple_path, l_simple_path * sizeof(char));
+                        simple_path = (char*) realloc(simple_path, l_simple_path * sizeof(char));
                         ASSERT_NULL_PTR(simple_path, "extract_core_simple_paths()\n");
 
                         simple_path[l_simple_path - 1] = succ[i].kmer[graph->k - 1];
@@ -513,7 +513,7 @@ size_t extract_core_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
 
                         l_simple_path++;
 
-                        simple_path = realloc(simple_path, l_simple_path * sizeof(char));
+                        simple_path = (char*) realloc(simple_path, l_simple_path * sizeof(char));
                         ASSERT_NULL_PTR(simple_path, "extract_core_simple_paths()\n");
 
                         memmove(&simple_path[1], simple_path, (l_simple_path - 1) * sizeof(char));
@@ -540,7 +540,7 @@ size_t extract_core_simple_paths(BFT_kmer* kmer, BFT* graph, va_list args){
                 }
             }
 
-            simple_path = realloc(simple_path, (l_simple_path+1) * sizeof(char));
+            simple_path = (char*) realloc(simple_path, (l_simple_path+1) * sizeof(char));
             ASSERT_NULL_PTR(simple_path, "extract_core_simple_paths()\n");
 
             simple_path[l_simple_path] = '\n';

--- a/src/write_to_disk.c
+++ b/src/write_to_disk.c
@@ -282,7 +282,7 @@ BFT_Root* read_BFT_Root_offset(char* filename, long int offset_read){
 
     if (root->length_comp_set_colors){
 
-        root->comp_set_colors = malloc(root->length_comp_set_colors * sizeof(annotation_array_elem));
+        root->comp_set_colors = (annotation_array_elem*) malloc(root->length_comp_set_colors * sizeof(annotation_array_elem));
         ASSERT_NULL_PTR(root->comp_set_colors, "read_BFT_Root() 2")
 
         for (i=0; i<root->length_comp_set_colors; i++){
@@ -297,7 +297,7 @@ BFT_Root* read_BFT_Root_offset(char* filename, long int offset_read){
 
             if (tmp){
 
-                root->comp_set_colors[i].annot_array = malloc(tmp * sizeof(uint8_t));
+                root->comp_set_colors[i].annot_array = (uint8_t*) malloc(tmp * sizeof(uint8_t));
                 ASSERT_NULL_PTR(root->comp_set_colors[i].annot_array, "read_BFT_Root() 3")
 
                 if (fread(root->comp_set_colors[i].annot_array, sizeof(uint8_t), tmp, file) != tmp) ERROR("read_BFT_Root()")
@@ -322,7 +322,7 @@ BFT_Root* read_BFT_Root_offset(char* filename, long int offset_read){
     else root->ann_inf = create_annotation_inform(root->nb_genomes, root->compressed == 1);
 
     if (root->nb_genomes){
-        root->filenames = malloc(root->nb_genomes * sizeof(char*));
+        root->filenames = (char**) malloc(root->nb_genomes * sizeof(char*));
         ASSERT_NULL_PTR(root->filenames, "read_BFT_Root() 4")
     }
 
@@ -330,7 +330,7 @@ BFT_Root* read_BFT_Root_offset(char* filename, long int offset_read){
 
         if (fread(&str_len, sizeof(uint16_t), 1, file) != 1) ERROR("read_BFT_Root()")
 
-        root->filenames[i] = malloc(str_len * sizeof(char));
+        root->filenames[i] = (char*) malloc(str_len * sizeof(char));
         ASSERT_NULL_PTR(root->filenames[i], "read_BFT_Root()")
 
         if (fread(root->filenames[i], sizeof(char), str_len, file) != str_len) ERROR("read_BFT_Root()")
@@ -372,7 +372,7 @@ void read_Node(Node* node, BFT_Root* root, int lvl_node, FILE* file, int size_km
 
     if (count_ccs){
 
-        node->CC_array = malloc(count_ccs * sizeof(CC));
+        node->CC_array = (CC*) malloc(count_ccs * sizeof(CC));
         ASSERT_NULL_PTR(node->CC_array,"read_Node()\n")
 
         for (uint32_t i = 0; i < count_ccs; i++) read_CC(&(((CC*)node->CC_array)[i]), root, lvl_node, file, size_kmer);
@@ -417,7 +417,7 @@ void read_UC(UC* uc, BFT_Root* root, FILE* file, int size_substring, uint16_t nb
             size_uc_suffixes = nb_children * size_line + uc->nb_extended_annot * SIZE_BYTE_EXT_ANNOT
                                 + uc->nb_cplx_nodes * (uc->size_annot_cplx_nodes + SIZE_BYTE_CPLX_N);
 
-            uc->suffixes = malloc(size_uc_suffixes * sizeof(uint8_t));
+            uc->suffixes = (uint8_t*) malloc(size_uc_suffixes * sizeof(uint8_t));
             ASSERT_NULL_PTR(uc->suffixes, "read_UC() 4")
 
             if (fread(uc->suffixes, sizeof(uint8_t), size_uc_suffixes, file) != size_uc_suffixes) ERROR("read_UC() 5")
@@ -429,7 +429,7 @@ void read_UC(UC* uc, BFT_Root* root, FILE* file, int size_substring, uint16_t nb
 
                 size_uc_suffixes = nb_children * size_line;
 
-                uc->suffixes = calloc(size_uc_suffixes, sizeof(uint8_t));
+                uc->suffixes = (uint8_t*) calloc(size_uc_suffixes, sizeof(uint8_t));
                 ASSERT_NULL_PTR(uc->suffixes, "read_UC()6 ")
 
                 for (i = 0, j = size_substring; i < nb_children * size_line; i += size_line, j = size_substring){
@@ -472,7 +472,7 @@ void read_UC(UC* uc, BFT_Root* root, FILE* file, int size_substring, uint16_t nb
 
             decomp_size_line = size_substring + size_decomp;
 
-            uc_suffixes_tmp = calloc(nb_children * decomp_size_line, sizeof(uint8_t));
+            uc_suffixes_tmp = (uint8_t*) calloc(nb_children * decomp_size_line, sizeof(uint8_t));
             ASSERT_NULL_PTR(uc->suffixes, "read_UC() 8")
 
             for (i = 0, j = 0, k = 0; j < nb_children; i += size_line, j++, k += decomp_size_line){
@@ -570,7 +570,7 @@ void read_CC(CC*  cc, BFT_Root* root, int lvl_cc, FILE* file, int size_kmer){
     if (cc->nb_elem >= root->info_per_lvl[lvl_cc].tresh_suf_pref) skipFilter2 = MASK_POWER_16[p]/root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter2; //SkipFilter2
     else skipFilter2 = 0;
 
-    cc->BF_filter2 = calloc(bf_filter2 + skipFilter2 + skipFilter3, sizeof(uint8_t));
+    cc->BF_filter2 = (uint8_t*) calloc(bf_filter2 + skipFilter2 + skipFilter3, sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->BF_filter2,"read_CC() 4")
     if (fread(&(cc->BF_filter2[size_bf]), sizeof(uint8_t), bf_filter2-size_bf, file) != bf_filter2 - size_bf)
         ERROR("read_CC() 5")
@@ -584,23 +584,23 @@ void read_CC(CC*  cc, BFT_Root* root, int lvl_cc, FILE* file, int size_kmer){
     else if (IS_ODD(cc->nb_elem)) tmp = (cc->nb_elem/2)+1;
     else tmp = cc->nb_elem/2;
 
-    cc->filter3 = malloc(tmp * sizeof(uint8_t));
+    cc->filter3 = (uint8_t*) malloc(tmp * sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->filter3,"read_CC()6")
     if (fread(cc->filter3, sizeof(uint8_t), tmp, file) != tmp) ERROR("read_CC() 7")
 
     if (root->info_per_lvl[lvl_cc].level_min == 1){
         tmp = CEIL(cc->nb_elem,SIZE_BITS_UINT_8T);
-        cc->extra_filter3 = malloc(tmp * sizeof(uint8_t));
+        cc->extra_filter3 = (uint8_t*) malloc(tmp * sizeof(uint8_t));
         ASSERT_NULL_PTR(cc->extra_filter3,"read_CC() 8")
         if (fread(cc->extra_filter3, sizeof(uint8_t), tmp, file) != tmp) ERROR("read_CC() 9")
     }
     else cc->extra_filter3 = NULL;
 
-    cc->children = malloc(nb_skp * sizeof(UC));
+    cc->children = (UC*) malloc(nb_skp * sizeof(UC));
     ASSERT_NULL_PTR(cc->children,"read_CC() 10")
 
     if (cc->nb_Node_children != 0){
-        cc->children_Node_container = malloc(cc->nb_Node_children * sizeof(Node));
+        cc->children_Node_container = (Node*) malloc(cc->nb_Node_children * sizeof(Node));
         ASSERT_NULL_PTR(cc->children_Node_container,"read_CC() 11")
     }
     else cc->children_Node_container = NULL;
@@ -608,13 +608,13 @@ void read_CC(CC*  cc, BFT_Root* root, int lvl_cc, FILE* file, int size_kmer){
     if (lvl_cc){
 
         if (type){
-            cc->children_type = malloc(cc->nb_elem * sizeof(uint8_t));
+            cc->children_type = (uint8_t*) malloc(cc->nb_elem * sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->children_type,"read_CC() 13")
             if (fread(cc->children_type, sizeof(uint8_t), (size_t)cc->nb_elem, file) != (size_t)cc->nb_elem)
                 ERROR("read_CC() 14");
         }
         else{
-            cc->children_type = malloc(CEIL(cc->nb_elem,2) * sizeof(uint8_t));
+            cc->children_type = (uint8_t*) malloc(CEIL(cc->nb_elem,2) * sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->children_type,"read_CC() 15")
             if (fread(cc->children_type, sizeof(uint8_t), (size_t)CEIL(cc->nb_elem,2), file) != (size_t)CEIL(cc->nb_elem,2))
                 ERROR("read_CC() 16")
@@ -825,7 +825,7 @@ void read_annotation_array_elem(char* filename, annotation_array_elem** annot_so
 
     if (*size_array){
 
-        *annot_sorted = malloc(*size_array * sizeof(annotation_array_elem));
+        *annot_sorted = (annotation_array_elem*) malloc(*size_array * sizeof(annotation_array_elem));
         ASSERT_NULL_PTR(*annot_sorted, "read_annotation_array_elem()\n")
 
         for (int i = 0; i < *size_array; i++){
@@ -840,7 +840,7 @@ void read_annotation_array_elem(char* filename, annotation_array_elem** annot_so
 
             if (tmp){
 
-                (*annot_sorted)[i].annot_array = malloc(tmp * sizeof(uint8_t));
+                (*annot_sorted)[i].annot_array = (uint8_t*) malloc(tmp * sizeof(uint8_t));
                 ASSERT_NULL_PTR((*annot_sorted)[i].annot_array, "read_annotation_array_elem()\n")
 
                 if (fread((*annot_sorted)[i].annot_array, sizeof(uint8_t), tmp, file) != tmp) ERROR("read_annotation_array_elem()\n")
@@ -928,7 +928,7 @@ void read_BFT_replace_comp_annots_bis(BFT_Root* root, char* filename_bft, char* 
 
     if (root->length_comp_set_colors){
 
-        root->comp_set_colors = malloc(root->length_comp_set_colors * sizeof(annotation_array_elem));
+        root->comp_set_colors = (annotation_array_elem*) malloc(root->length_comp_set_colors * sizeof(annotation_array_elem));
         ASSERT_NULL_PTR(root->comp_set_colors, "read_BFT_replace_comp_annots() 2")
 
         for (i = 0; i < root->length_comp_set_colors; i++){
@@ -943,7 +943,7 @@ void read_BFT_replace_comp_annots_bis(BFT_Root* root, char* filename_bft, char* 
 
             if (tmp){
 
-                root->comp_set_colors[i].annot_array = malloc(tmp * sizeof(uint8_t));
+                root->comp_set_colors[i].annot_array = (uint8_t*) malloc(tmp * sizeof(uint8_t));
                 ASSERT_NULL_PTR(root->comp_set_colors[i].annot_array, "read_BFT_replace_comp_annots() 3")
 
                 if (fread(root->comp_set_colors[i].annot_array, sizeof(uint8_t), tmp, file) != tmp) ERROR("read_BFT_replace_comp_annots()")
@@ -969,14 +969,14 @@ void read_BFT_replace_comp_annots_bis(BFT_Root* root, char* filename_bft, char* 
     if (root->compressed) root->ann_inf = create_annotation_inform(-1, root->compressed == 1);
     else root->ann_inf = create_annotation_inform(root->nb_genomes, root->compressed == 1);
 
-    root->filenames = malloc(root->nb_genomes * sizeof(char*));
+    root->filenames = (char**) malloc(root->nb_genomes * sizeof(char*));
     ASSERT_NULL_PTR(root->filenames, "read_BFT_replace_comp_annots() 4")
 
     for (i = 0; i < root->nb_genomes; i++){
 
         if (fread(&str_len, sizeof(uint16_t), 1, file) != 1) ERROR("read_BFT_replace_comp_annots()")
 
-        root->filenames[i] = malloc(str_len * sizeof(char));
+        root->filenames[i] = (char*) malloc(str_len * sizeof(char));
         ASSERT_NULL_PTR(root->filenames[i], "read_BFT_replace_comp_annots()")
 
         if (fread(root->filenames[i], sizeof(char), str_len, file) != str_len) ERROR("read_BFT_replace_comp_annots()")
@@ -1022,7 +1022,7 @@ void read_Node_replace_comp_annots(Node* node, BFT_Root* root, int lvl_node, FIL
 
     if (count_ccs){
 
-        node->CC_array = malloc(count_ccs * sizeof(CC));
+        node->CC_array = (CC*) malloc(count_ccs * sizeof(CC));
         ASSERT_NULL_PTR(node->CC_array,"read_Node_replace_comp_annots()\n")
 
         for (uint32_t i = 0; i < count_ccs; i++)
@@ -1070,7 +1070,7 @@ void read_CC_replace_comp_annots(CC* cc, BFT_Root* root, int lvl_cc, FILE* file,
     if (cc->nb_elem >= root->info_per_lvl[lvl_cc].tresh_suf_pref) skipFilter2 = MASK_POWER_16[p]/root->info_per_lvl[lvl_cc].nb_bits_per_cell_skip_filter2; //SkipFilter2
     else skipFilter2 = 0;
 
-    cc->BF_filter2 = calloc(bf_filter2 + skipFilter2 + skipFilter3, sizeof(uint8_t));
+    cc->BF_filter2 = (uint8_t*) calloc(bf_filter2 + skipFilter2 + skipFilter3, sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->BF_filter2,"read_CC_replace_comp_annots()\n")
 
     if (fread(&(cc->BF_filter2[size_bf]), sizeof(uint8_t), bf_filter2-size_bf, file) != bf_filter2 - size_bf)
@@ -1085,24 +1085,24 @@ void read_CC_replace_comp_annots(CC* cc, BFT_Root* root, int lvl_cc, FILE* file,
     else if (IS_ODD(cc->nb_elem)) tmp = (cc->nb_elem/2)+1;
     else tmp = cc->nb_elem/2;
 
-    cc->filter3 = malloc(tmp * sizeof(uint8_t));
+    cc->filter3 = (uint8_t*) malloc(tmp * sizeof(uint8_t));
     ASSERT_NULL_PTR(cc->filter3,"read_CC_replace_comp_annots()\n")
 
     if (fread(cc->filter3, sizeof(uint8_t), tmp, file) != tmp) ERROR("read_CC_replace_comp_annots()\n")
 
     if (root->info_per_lvl[lvl_cc].level_min == 1){
         tmp = CEIL(cc->nb_elem,SIZE_BITS_UINT_8T);
-        cc->extra_filter3 = malloc(tmp * sizeof(uint8_t));
+        cc->extra_filter3 = (uint8_t*) malloc(tmp * sizeof(uint8_t));
         ASSERT_NULL_PTR(cc->extra_filter3,"read_CC_replace_comp_annots()\n")
         if (fread(cc->extra_filter3, sizeof(uint8_t), tmp, file) != tmp) ERROR("read_CC_replace_comp_annots()\n")
     }
     else cc->extra_filter3 = NULL;
 
-    cc->children = malloc(nb_skp * sizeof(UC));
+    cc->children = (UC*) malloc(nb_skp * sizeof(UC));
     ASSERT_NULL_PTR(cc->children,"read_CC_replace_comp_annots()\n")
 
     if (cc->nb_Node_children != 0){
-        cc->children_Node_container = malloc(cc->nb_Node_children * sizeof(Node));
+        cc->children_Node_container = (Node*) malloc(cc->nb_Node_children * sizeof(Node));
         ASSERT_NULL_PTR(cc->children_Node_container,"read_CC_replace_comp_annots()\n")
     }
     else cc->children_Node_container = NULL;
@@ -1110,13 +1110,13 @@ void read_CC_replace_comp_annots(CC* cc, BFT_Root* root, int lvl_cc, FILE* file,
     if (lvl_cc){
 
         if (type){
-            cc->children_type = malloc(cc->nb_elem * sizeof(uint8_t));
+            cc->children_type = (uint8_t*) malloc(cc->nb_elem * sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->children_type,"read_CC_replace_comp_annots()\n")
             if (fread(cc->children_type, sizeof(uint8_t), (size_t)cc->nb_elem, file) != (size_t)cc->nb_elem)
                 ERROR("read_CC_replace_comp_annots()\n");
         }
         else{
-            cc->children_type = malloc(CEIL(cc->nb_elem,2) * sizeof(uint8_t));
+            cc->children_type = (uint8_t*) malloc(CEIL(cc->nb_elem,2) * sizeof(uint8_t));
             ASSERT_NULL_PTR(cc->children_type,"read_CC() 15")
             if (fread(cc->children_type, sizeof(uint8_t), (size_t)CEIL(cc->nb_elem,2), file) != (size_t)CEIL(cc->nb_elem,2))
                 ERROR("read_CC_replace_comp_annots()\n")

--- a/src/xxhsum.c
+++ b/src/xxhsum.c
@@ -323,7 +323,7 @@ static int BMK_benchFiles(const char** fileNamesTable, int nbFiles)
 static int BMK_benchInternal(void)
 {
     size_t const benchedSize = g_sampleSize;
-    void* const buffer = calloc(benchedSize+3, 1);
+    void* const buffer = (void*) calloc(benchedSize+3, 1);
     if(!buffer) {
         DISPLAY("\nError: not enough memory!\n");
         return 12;
@@ -530,7 +530,7 @@ static int BMK_hash(const char* fileName,
     }
 
     /* Memory allocation & restrictions */
-    buffer = malloc(blockSize);
+    buffer = (void*) malloc(blockSize);
     if(!buffer) {
         DISPLAY("\nError: not enough memory!\n");
         fclose(inFile);


### PR DESCRIPTION
In order to use this project in a C++ project, one used to have to supply the `-fpermissive` flag because C++ didn't like the freshly malloc'd memory not being type-casted to the resulting type. 

These changes type-cast each of these occurrences such that the `-fpermissive` compiler flag is not longer needed.  