### PR TITLE
fixed insertion traversal

### DIFF
--- a/src/CC.c
+++ b/src/CC.c
@@ -608,7 +608,7 @@ void transform2CC_from_arraySuffix(uint8_t*  array_suffix, CC*  cc, BFT_Root* ro
         else{
             int j=0;
 
-            if (size_suffix != 36) array_suffix[real_pos_i_uc+nb_cell-1] &= 0x7f;
+            if ((size_suffix != 36) && (size_suffix != 72) && (size_suffix != 108))  array_suffix[real_pos_i_uc+nb_cell-1] &= 0x7f;
 
             int nb_cell_to_delete = 2 + ((size_suffix == 45) || (size_suffix == 81) || (size_suffix == 117));
 

--- a/src/insertNode.c
+++ b/src/insertNode.c
@@ -265,7 +265,7 @@ Node* insertKmer_Node_special(BFT_Root*  root, int lvl_cont, uint8_t*  suffix, i
     int pos = 0;
     int inside = 1;
 
-    if (size_suffix == 36){
+    if ((size_suffix == 36) || (size_suffix == 72) || (size_suffix == 108)){
         pos = binary_search_UC_array((uint8_t*)pres->link_child, size_annot, 0, nb_elt - 1, suffix, nb_cell, 0xff);
         inside = memcmp(&(((uint8_t*)pres->link_child)[pos * size_line]), suffix, nb_cell * sizeof(uint8_t));
         if (inside < 0) pos++;


### PR DESCRIPTION
the insertion traversal was different than get_kmer\'s, this fixes the discrepancy